### PR TITLE
Removes unnecessary final modifiers on parameters

### DIFF
--- a/java/daikon/Quant.java.jpp
+++ b/java/daikon/Quant.java.jpp
@@ -111,7 +111,7 @@ public final class Quant {
   /** True iff the sequence contains no null elements. */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsNonNull(final Object[] seq1) {
+  public static boolean eltsNonNull(Object[] seq1) {
     if (seq1 == null) { return false; }
     for (int i = 0 ; i < seq1.length ; i++) {
       if (seq1[i] == null) {
@@ -176,7 +176,7 @@ public final class Quant {
   @SuppressWarnings("interning") // cast from Object
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean noDups(final Object seq) {
+  public static boolean noDups(Object seq) {
     if (seq == null) { return false; }
     return noDups(toObjArray(seq));
   }
@@ -195,7 +195,7 @@ public final class Quant {
   @SuppressWarnings("interning") // cast from Object
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltwiseEqual(final Object seq) {
+  public static boolean eltwiseEqual(Object seq) {
     if (seq == null) { return false; }
     return eltwiseEqual(toObjArray(seq));
   }
@@ -205,7 +205,7 @@ public final class Quant {
   @SuppressWarnings("interning") // cast from Object
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltwiseNotEqual(final Object seq) {
+  public static boolean eltwiseNotEqual(Object seq) {
     if (seq == null) { return false; }
     return eltwiseNotEqual(toObjArray(seq));
   }
@@ -259,7 +259,7 @@ public final class Quant {
   @SuppressWarnings("interning")  // cast from Object
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean setEqual(/*@Nullable*/ Object seq1, final /*@Nullable*/ Object seq2) {
+  public static boolean setEqual(/*@Nullable*/ Object seq1, /*@Nullable*/ Object seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     return setEqual(toObjArray(seq1), toObjArray(seq2));
@@ -335,7 +335,7 @@ public final class Quant {
   @SuppressWarnings("interning")  // cast from Object
   /*TODO: @AssertNonNullIfNonNull("#1")*/
   /*@SideEffectFree*/
-  public static Object /*@PolyNull*/ [] slice(final /*@PolyNull*/ Object seq, int start, int end) {
+  public static Object /*@PolyNull*/ [] slice(/*@PolyNull*/ Object seq, int start, int end) {
     if (seq == null) { return null; }
     return slice(toObjArray(seq), start, end);
   }
@@ -345,7 +345,7 @@ public final class Quant {
   @SuppressWarnings("interning")  // cast from Object
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsEqual(final /*@Nullable*/ Object arr, Object elt) {
+  public static boolean eltsEqual(/*@Nullable*/ Object arr, Object elt) {
     if (arr == null) { return false; }
     return eltsEqual(toObjArray(arr), elt);
   }
@@ -355,14 +355,14 @@ public final class Quant {
   @SuppressWarnings("interning")  // cast from Object
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsNotEqual(final /*@Nullable*/ Object arr, Object elt) {
+  public static boolean eltsNotEqual(/*@Nullable*/ Object arr, Object elt) {
     if (arr == null) { return false; }
     return eltsNotEqual(toObjArray(arr), elt);
   }
 
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean isIntegralType(final /*@Nullable*/ Class<?> c) {
+  public static boolean isIntegralType(/*@Nullable*/ Class<?> c) {
     if (c == null) { return false; }
     return
       (c.equals(Byte.TYPE) ||
@@ -373,7 +373,7 @@ public final class Quant {
 
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean isRealType(final /*@Nullable*/ Class<?> c) {
+  public static boolean isRealType(/*@Nullable*/ Class<?> c) {
     if (c == null) { return false; }
     return
       (c.equals(Float.TYPE) ||
@@ -382,7 +382,7 @@ public final class Quant {
 
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean isNumericType(final Class<?> c) {
+  public static boolean isNumericType(Class<?> c) {
     if (c == null) { return false; }
     return isIntegralType(c) || isRealType(c);
   }
@@ -391,7 +391,7 @@ public final class Quant {
    * AbstractCollection.
    */
   /*TODO: @AssertNonNullIfNonNull("#1")*/
-  public static Object /*@PolyNull*/ [] toObjArray(final /*@PolyNull*/ Object o) {
+  public static Object /*@PolyNull*/ [] toObjArray(/*@PolyNull*/ Object o) {
     if (o == null) { return null; }
     if (o instanceof java.util.AbstractCollection<?>) {
       @SuppressWarnings({"unchecked", "interning"})

--- a/java/daikon/Quant.java.jpp
+++ b/java/daikon/Quant.java.jpp
@@ -259,7 +259,7 @@ public final class Quant {
   @SuppressWarnings("interning")  // cast from Object
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean setEqual(final /*@Nullable*/ Object seq1, final /*@Nullable*/ Object seq2) {
+  public static boolean setEqual(/*@Nullable*/ Object seq1, final /*@Nullable*/ Object seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     return setEqual(toObjArray(seq1), toObjArray(seq2));
@@ -270,7 +270,7 @@ public final class Quant {
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   @SuppressWarnings("interning")  // cast from Object
   /*@Pure*/
-  public static boolean isReverse(final /*@Nullable*/ Object seq1, final /*@Nullable*/ Object seq2) {
+  public static boolean isReverse(/*@Nullable*/ Object seq1, /*@Nullable*/ Object seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     return isReverse(toObjArray(seq1), toObjArray(seq2));
@@ -281,7 +281,7 @@ public final class Quant {
   @SuppressWarnings("interning")  // cast from Object
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseEqual(final /*@Nullable*/ Object seq1, final /*@Nullable*/ Object seq2) {
+  public static boolean pairwiseEqual(/*@Nullable*/ Object seq1, /*@Nullable*/ Object seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     return pairwiseEqual(toObjArray(seq1), toObjArray(seq2));
@@ -292,7 +292,7 @@ public final class Quant {
   @SuppressWarnings("interning")  // cast from Object
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseNotEqual(final /*@Nullable*/ Object seq1, final /*@Nullable*/ Object seq2) {
+  public static boolean pairwiseNotEqual(/*@Nullable*/ Object seq1, /*@Nullable*/ Object seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     return pairwiseNotEqual(toObjArray(seq1), toObjArray(seq2));
@@ -303,7 +303,7 @@ public final class Quant {
   @SuppressWarnings("interning")  // cast from Object
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexEqual(final /*@Nullable*/ Object seq1, final /*@Nullable*/ Object seq2) {
+  public static boolean lexEqual(/*@Nullable*/ Object seq1, /*@Nullable*/ Object seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     return lexEqual(toObjArray(seq1), toObjArray(seq2));
@@ -314,7 +314,7 @@ public final class Quant {
   @SuppressWarnings("interning")  // cast from Object
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexNotEqual(final /*@Nullable*/ Object seq1, final /*@Nullable*/ Object seq2) {
+  public static boolean lexNotEqual(/*@Nullable*/ Object seq1, /*@Nullable*/ Object seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     return lexNotEqual(toObjArray(seq1), toObjArray(seq2));
@@ -325,7 +325,7 @@ public final class Quant {
   @SuppressWarnings("interning")  // cast from Object
   /*@EnsuresNonNullIf(result=true, expression="#2")*/
   /*@Pure*/
-  public static boolean memberOf(Object elt, final /*@Nullable*/ Object arr) {
+  public static boolean memberOf(Object elt, /*@Nullable*/ Object arr) {
     if (arr == null) { return false; }
     return memberOf(elt, toObjArray(arr));
   }

--- a/java/daikon/QuantBody.java.jpp
+++ b/java/daikon/QuantBody.java.jpp
@@ -108,7 +108,7 @@ The correct way to build the system is to run 'make'.
 
 
 #if 0
-  For an explanation of the indirection, see 
+  For an explanation of the indirection, see
   http://stackoverflow.com/questions/8231966/why-do-i-need-double-layer-of-indirection-for-macros
 #endif
 #define COLLECT_TYPE COLLECT_TYPE2(_TYPE_NAME)
@@ -171,7 +171,7 @@ The correct way to build the system is to run 'make'.
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
 #endif
   /*@Pure*/
-  public static BAD_VALUE_QUALIFIER _TYPE GET_ELEMENT (final Object o, long i) {
+  public static BAD_VALUE_QUALIFIER _TYPE GET_ELEMENT (Object o, long i) {
     if (o == null) { return BAD_VALUE; } // return default value
     java.lang.Class<?> c = o.getClass();
     if (c.isArray()) {
@@ -188,7 +188,7 @@ The correct way to build the system is to run 'make'.
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
 #endif
   /*@Pure*/
-  public static BAD_VALUE_QUALIFIER _TYPE GET_ELEMENT (final _TYPE_NAME[] arr, long i) {
+  public static BAD_VALUE_QUALIFIER _TYPE GET_ELEMENT (_TYPE_NAME[] arr, long i) {
     if (arr == null) { return BAD_VALUE; } // return default value
     return arr[(int)i];
   }
@@ -276,7 +276,7 @@ The correct way to build the system is to run 'make'.
   /** True iff both sequences are non-null and have the same length. */
   /*@EnsuresNonNullIf(result=true, expression={"#1", "#2"})*/
   /*@Pure*/
-  public static boolean sameLength(final _TYPE_NAME /*@Nullable*/ [] seq1, final _TYPE_NAME /*@Nullable*/ [] seq2) {
+  public static boolean sameLength(_TYPE_NAME /*@Nullable*/ [] seq1, _TYPE_NAME /*@Nullable*/ [] seq2) {
     return ((seq1 != null)
             && (seq2 != null)
             && seq1.length == seq2.length);
@@ -286,7 +286,7 @@ The correct way to build the system is to run 'make'.
   /** True iff both sequences are non-null and have the same length. */
   /*@EnsuresNonNullIf(result=true, expression={"#1", "#2"})*/
   /*@Pure*/
-  public static boolean sameLength(final _TYPE_NAME /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean sameLength(_TYPE_NAME /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     return ((seq1 != null)
             && (seq2 != null)
             && seq1.length == seq2.length);
@@ -307,7 +307,7 @@ The correct way to build the system is to run 'make'.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseDivides(final _TYPE[] seq1, final _TYPE[] seq2) {
+  public static boolean pairwiseDivides(_TYPE[] seq1, _TYPE[] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -319,7 +319,7 @@ The correct way to build the system is to run 'make'.
   }
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseDivides(final _TYPE[] seq1, final COMPATIBLE[] seq2) {
+  public static boolean pairwiseDivides(_TYPE[] seq1, COMPATIBLE[] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -342,7 +342,7 @@ The correct way to build the system is to run 'make'.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseSquare(final _TYPE[] seq1, final _TYPE[] seq2) {
+  public static boolean pairwiseSquare(_TYPE[] seq1, _TYPE[] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -354,7 +354,7 @@ The correct way to build the system is to run 'make'.
   }
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseSquare(final _TYPE[] seq1, final COMPATIBLE[] seq2) {
+  public static boolean pairwiseSquare(_TYPE[] seq1, COMPATIBLE[] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -385,7 +385,7 @@ The correct way to build the system is to run 'make'.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseBitwiseComplement(final _TYPE[] seq1, final _TYPE[] seq2) {
+  public static boolean pairwiseBitwiseComplement(_TYPE[] seq1, _TYPE[] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -397,7 +397,7 @@ The correct way to build the system is to run 'make'.
   }
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseBitwiseComplement(final _TYPE[] seq1, final COMPATIBLE[] seq2) {
+  public static boolean pairwiseBitwiseComplement(_TYPE[] seq1, COMPATIBLE[] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -415,7 +415,7 @@ The test ensures that the method only appears once in the output.
 #if (defined(INT))
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseBitwiseComplement(final Object[] seq1, final Object[] seq2) {
+  public static boolean pairwiseBitwiseComplement(Object[] seq1, Object[] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     if (! eltsNonNull(seq1)) { return false; }
@@ -444,7 +444,7 @@ The test ensures that the method only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseBitwiseSubset(final _TYPE[] seq1, final _TYPE[] seq2) {
+  public static boolean pairwiseBitwiseSubset(_TYPE[] seq1, _TYPE[] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     if (seq1.length != seq2.length) {
@@ -459,7 +459,7 @@ The test ensures that the method only appears once in the output.
   }
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseBitwiseSubset(final _TYPE[] seq1, final COMPATIBLE[] seq2) {
+  public static boolean pairwiseBitwiseSubset(_TYPE[] seq1, COMPATIBLE[] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -477,7 +477,7 @@ The test ensures that the method only appears once in the output.
 #if (defined(INT))
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseBitwiseSubset(final Object[] seq1, final Object[] seq2) {
+  public static boolean pairwiseBitwiseSubset(Object[] seq1, Object[] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     if (! eltsNonNull(seq1)) { return false; }
@@ -670,7 +670,7 @@ The test ensures that the method only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean setEqual(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean setEqual(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     for (int i = 0; i < seq1.length ; i++) {
@@ -689,7 +689,7 @@ The test ensures that the method only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean setEqual(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean setEqual(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     for (int i = 0; i < seq1.length ; i++) {
@@ -719,7 +719,7 @@ The test ensures that the method only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean isReverse(final _TYPE[] seq1, final _TYPE[] seq2) {
+  public static boolean isReverse(_TYPE[] seq1, _TYPE[] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     int length = seq1.length;
@@ -734,7 +734,7 @@ The test ensures that the method only appears once in the output.
 #if (defined(OBJECT))
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean isReverse(final /*@PolyNull*/ Collection<? extends _TYPE> seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean isReverse(/*@PolyNull*/ Collection<? extends _TYPE> seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     _TYPE[] seq1_array = seq1.toArray(new _TYPE[]{});
@@ -745,7 +745,7 @@ The test ensures that the method only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean isReverse(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean isReverse(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     int length = seq1.length;
@@ -774,7 +774,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean subsetOf(final /*@Nullable*/ Object elts, final /*@Nullable*/ Object arr) {
+  public static boolean subsetOf(/*@Nullable*/ Object elts, /*@Nullable*/ Object arr) {
     if (elts == null) { return false; }
     if (arr == null) { return false; }
     if (!(elts.getClass().isArray() && arr.getClass().isArray())) {
@@ -839,7 +839,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean subsetOf(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean subsetOf(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -853,7 +853,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean subsetOf(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean subsetOf(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -868,7 +868,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #if (defined(OBJECT))
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean subsetOf(final /*@Nullable*/ Collection<? extends _TYPE> seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean subsetOf(/*@Nullable*/ Collection<? extends _TYPE> seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     _TYPE[] seq1_array = seq1.toArray(new _TYPE[]{});
@@ -877,7 +877,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean subsetOf(final _TYPE /*@Nullable*/ [] seq1, final /*@Nullable*/ Collection<? extends _TYPE> seq2) {
+  public static boolean subsetOf(_TYPE /*@Nullable*/ [] seq1, /*@Nullable*/ Collection<? extends _TYPE> seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     _TYPE[] seq2_array = seq2.toArray(new _TYPE[]{});
@@ -891,7 +891,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean noDups(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean noDups(_TYPE /*@Nullable*/ [] seq) {
     if (seq == null) { return false; }
     return plume.ArraysMDE.noDuplicates(seq);
   }
@@ -901,7 +901,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
   */
   /*@EnsuresNonNullIf(result=true, expression="#2")*/
   /*@Pure*/
-  public static boolean memberOf(_TYPE elt, final _TYPE /*@Nullable*/ [] arr) {
+  public static boolean memberOf(_TYPE elt, _TYPE /*@Nullable*/ [] arr) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (eq(arr[i], elt)) { return true; }
@@ -912,7 +912,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression="#2")*/
   /*@Pure*/
-  public static boolean memberOf(_TYPE elt, final COMPATIBLE /*@Nullable*/ [] arr) {
+  public static boolean memberOf(_TYPE elt, COMPATIBLE /*@Nullable*/ [] arr) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (eq(arr[i], elt)) { return true; }
@@ -924,7 +924,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #if (defined(BYTE) || defined(SHORT))
   /*@EnsuresNonNullIf(result=true, expression="#2")*/
   /*@Pure*/
-  public static boolean memberOf(long elt, final _TYPE /*@Nullable*/ [] arr) {
+  public static boolean memberOf(long elt, _TYPE /*@Nullable*/ [] arr) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (eq(arr[i], elt)) { return true; }
@@ -973,7 +973,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsEqual(final _TYPE /*@Nullable*/ [] arr, _TYPE elt) {
+  public static boolean eltsEqual(_TYPE /*@Nullable*/ [] arr, _TYPE elt) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (ne(arr[i], elt)) { return false; }
@@ -984,7 +984,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsEqual(final _TYPE /*@Nullable*/ [] arr, COMPATIBLE elt) {
+  public static boolean eltsEqual(_TYPE /*@Nullable*/ [] arr, COMPATIBLE elt) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (ne(arr[i], elt)) { return false; }
@@ -1002,7 +1002,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsNotEqual(final _TYPE /*@Nullable*/ [] arr, _TYPE elt) {
+  public static boolean eltsNotEqual(_TYPE /*@Nullable*/ [] arr, _TYPE elt) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (eq(arr[i], elt)) { return false; }
@@ -1013,7 +1013,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsNotEqual(final _TYPE /*@Nullable*/ [] arr, COMPATIBLE elt) {
+  public static boolean eltsNotEqual(_TYPE /*@Nullable*/ [] arr, COMPATIBLE elt) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (eq(arr[i], elt)) { return false; }
@@ -1033,7 +1033,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsGT(final _TYPE /*@Nullable*/ [] arr, _TYPE elt) {
+  public static boolean eltsGT(_TYPE /*@Nullable*/ [] arr, _TYPE elt) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (lte(arr[i], elt)) { return false; }
@@ -1044,7 +1044,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsGT(final _TYPE /*@Nullable*/ [] arr, COMPATIBLE elt) {
+  public static boolean eltsGT(_TYPE /*@Nullable*/ [] arr, COMPATIBLE elt) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (lte(arr[i], elt)) { return false; }
@@ -1062,7 +1062,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsGTE(final _TYPE /*@Nullable*/ [] arr, _TYPE elt) {
+  public static boolean eltsGTE(_TYPE /*@Nullable*/ [] arr, _TYPE elt) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (lt(arr[i], elt)) { return false; }
@@ -1073,7 +1073,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsGTE(final _TYPE /*@Nullable*/ [] arr, COMPATIBLE elt) {
+  public static boolean eltsGTE(_TYPE /*@Nullable*/ [] arr, COMPATIBLE elt) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (lt(arr[i], elt)) { return false; }
@@ -1091,7 +1091,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsLT(final _TYPE /*@Nullable*/ [] arr, _TYPE elt) {
+  public static boolean eltsLT(_TYPE /*@Nullable*/ [] arr, _TYPE elt) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (gte(arr[i], elt)) { return false; }
@@ -1102,7 +1102,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsLT(final _TYPE /*@Nullable*/ [] arr, COMPATIBLE elt) {
+  public static boolean eltsLT(_TYPE /*@Nullable*/ [] arr, COMPATIBLE elt) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (gte(arr[i], elt)) { return false; }
@@ -1120,7 +1120,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsLTE(final _TYPE /*@Nullable*/ [] arr, _TYPE elt) {
+  public static boolean eltsLTE(_TYPE /*@Nullable*/ [] arr, _TYPE elt) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (gt(arr[i], elt)) { return false; }
@@ -1131,7 +1131,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsLTE(final _TYPE /*@Nullable*/ [] arr, COMPATIBLE elt) {
+  public static boolean eltsLTE(_TYPE /*@Nullable*/ [] arr, COMPATIBLE elt) {
     if (arr == null) { return false; }
     for (int i = 0 ; i < arr.length ; i++) {
       if (gt(arr[i], elt)) { return false; }
@@ -1153,7 +1153,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #if (defined(FLOAT) || defined(DOUBLE))
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseEqual(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseEqual(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1169,7 +1169,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #else
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseEqual(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseEqual(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1184,7 +1184,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #if (defined(OBJECT) || defined(STRING))
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseEqual(final /*@Nullable*/ AbstractCollection<_TYPE> seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseEqual(/*@Nullable*/ AbstractCollection<_TYPE> seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     @SuppressWarnings("cast") // cast is redundant (except in JSR 308)
@@ -1194,7 +1194,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseEqual(final _TYPE /*@Nullable*/ [] seq1, final /*@Nullable*/ AbstractCollection<_TYPE> seq2) {
+  public static boolean pairwiseEqual(_TYPE /*@Nullable*/ [] seq1, /*@Nullable*/ AbstractCollection<_TYPE> seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     @SuppressWarnings("cast") // cast is redundant (except in JSR 308)
@@ -1206,7 +1206,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseEqual(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseEqual(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1228,7 +1228,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseNotEqual(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseNotEqual(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1242,7 +1242,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseNotEqual(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseNotEqual(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1266,7 +1266,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseLT(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseLT(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1280,7 +1280,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseLT(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseLT(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1301,7 +1301,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseLTE(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseLTE(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1315,7 +1315,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseLTE(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseLTE(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1336,7 +1336,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseGT(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseGT(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1350,7 +1350,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseGT(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseGT(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1371,7 +1371,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseGTE(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseGTE(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1385,7 +1385,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean pairwiseGTE(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean pairwiseGTE(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     if (! sameLength(seq1, seq2)) { return false; }
     assert seq1 != null && seq2 != null; // because sameLength() = true
     for (int i = 0 ; i < seq1.length ; i++) {
@@ -1405,7 +1405,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexEqual(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean lexEqual(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     return pairwiseEqual(seq1, seq2);
@@ -1414,7 +1414,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexEqual(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean lexEqual(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     return pairwiseEqual(seq1, seq2);
@@ -1426,7 +1426,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexNotEqual(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean lexNotEqual(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     return !lexEqual(seq1, seq2);
@@ -1435,7 +1435,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexNotEqual(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean lexNotEqual(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     return !lexEqual(seq1, seq2);
@@ -1449,7 +1449,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexLT(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean lexLT(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     int minlength = (seq1.length < seq2.length) ? seq1.length : seq2.length;
@@ -1470,7 +1470,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexLT(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean lexLT(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     int minlength = (seq1.length < seq2.length) ? seq1.length : seq2.length;
@@ -1493,7 +1493,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexLTE(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean lexLTE(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
     if (seq1 == null) { return false; }
     if (seq2 == null) { return false; }
     int minlength = (seq1.length < seq2.length) ? seq1.length : seq2.length;
@@ -1514,7 +1514,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexLTE(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean lexLTE(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
   if (seq1 == null) { return false; }
   if (seq2 == null) { return false; }
     int minlength = (seq1.length < seq2.length) ? seq1.length : seq2.length;
@@ -1537,7 +1537,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexGT(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean lexGT(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
   if (seq1 == null) { return false; }
   if (seq2 == null) { return false; }
     int minlength = (seq1.length < seq2.length) ? seq1.length : seq2.length;
@@ -1558,7 +1558,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexGT(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean lexGT(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
   if (seq1 == null) { return false; }
   if (seq2 == null) { return false; }
     int minlength = (seq1.length < seq2.length) ? seq1.length : seq2.length;
@@ -1581,7 +1581,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexGTE(final _TYPE /*@Nullable*/ [] seq1, final _TYPE /*@Nullable*/ [] seq2) {
+  public static boolean lexGTE(_TYPE /*@Nullable*/ [] seq1, _TYPE /*@Nullable*/ [] seq2) {
   if (seq1 == null) { return false; }
   if (seq2 == null) { return false; }
     int minlength = (seq1.length < seq2.length) ? seq1.length : seq2.length;
@@ -1601,7 +1601,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
 #ifdef COMPATIBLE
   /*@EnsuresNonNullIf(result=true, expression={"#1","#2"})*/
   /*@Pure*/
-  public static boolean lexGTE(final _TYPE /*@Nullable*/ [] seq1, final COMPATIBLE /*@Nullable*/ [] seq2) {
+  public static boolean lexGTE(_TYPE /*@Nullable*/ [] seq1, COMPATIBLE /*@Nullable*/ [] seq2) {
   if (seq1 == null) { return false; }
   if (seq2 == null) { return false; }
     int minlength = (seq1.length < seq2.length) ? seq1.length : seq2.length;
@@ -1630,7 +1630,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltwiseEqual(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean eltwiseEqual(_TYPE /*@Nullable*/ [] seq) {
   if (seq == null) { return false; }
     for (int i = 0 ; i < seq.length ; i++) {
       if (i < seq.length-1) {
@@ -1651,7 +1651,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltwiseNotEqual(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean eltwiseNotEqual(_TYPE /*@Nullable*/ [] seq) {
   if (seq == null) { return false; }
     for (int i = 0 ; i < seq.length ; i++) {
       if (i < seq.length-1) {
@@ -1674,7 +1674,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltwiseLT(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean eltwiseLT(_TYPE /*@Nullable*/ [] seq) {
   if (seq == null) { return false; }
     for (int i = 0 ; i < seq.length ; i++) {
       if (i < seq.length-1) {
@@ -1695,7 +1695,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltwiseLTE(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean eltwiseLTE(_TYPE /*@Nullable*/ [] seq) {
   if (seq == null) { return false; }
     for (int i = 0 ; i < seq.length ; i++) {
       if (i < seq.length-1) {
@@ -1716,7 +1716,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltwiseGT(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean eltwiseGT(_TYPE /*@Nullable*/ [] seq) {
   if (seq == null) { return false; }
     for (int i = 0 ; i < seq.length ; i++) {
       if (i < seq.length-1) {
@@ -1737,7 +1737,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltwiseGTE(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean eltwiseGTE(_TYPE /*@Nullable*/ [] seq) {
   if (seq == null) { return false; }
     for (int i = 0 ; i < seq.length ; i++) {
       if (i < seq.length-1) {
@@ -1761,7 +1761,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsEqualIndex(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean eltsEqualIndex(_TYPE /*@Nullable*/ [] seq) {
   if (seq == null) { return false; }
     for (int i = 0 ; i < seq.length ; i++) {
       if (ne(seq[i], i)) {
@@ -1780,7 +1780,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsNotEqualIndex(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean eltsNotEqualIndex(_TYPE /*@Nullable*/ [] seq) {
   if (seq == null) { return false; }
     for (int i = 0 ; i < seq.length ; i++) {
       if (eq(seq[i], i)) {
@@ -1799,7 +1799,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsLtIndex(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean eltsLtIndex(_TYPE /*@Nullable*/ [] seq) {
   if (seq == null) { return false; }
     for (int i = 0 ; i < seq.length ; i++) {
       if (gte(seq[i], i)) {
@@ -1818,7 +1818,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsLteIndex(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean eltsLteIndex(_TYPE /*@Nullable*/ [] seq) {
   if (seq == null) { return false; }
     for (int i = 0 ; i < seq.length ; i++) {
       if (gt(seq[i], i)) {
@@ -1837,7 +1837,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean  eltsGtIndex(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean  eltsGtIndex(_TYPE /*@Nullable*/ [] seq) {
   if (seq == null) { return false; }
     for (int i = 0 ; i < seq.length ; i++) {
       if (lte(seq[i], i)) {
@@ -1856,7 +1856,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    */
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public static boolean eltsGteIndex(final _TYPE /*@Nullable*/ [] seq) {
+  public static boolean eltsGteIndex(_TYPE /*@Nullable*/ [] seq) {
   if (seq == null) { return false; }
     for (int i = 0 ; i < seq.length ; i++) {
       if (lt(seq[i], i)) {
@@ -1902,7 +1902,7 @@ The "defined(INT)" test ensures that it only appears once in the output.
    * one field representing an array. For example, the collection
    * a[].b[].c will fail.
    * <p>
-   * 
+   *
    * @return if the resulting collection is of non-primitive type, then
    * returns an array of type Object[].
    * Returns null if any array or field access causes an exception.

--- a/java/daikon/VarComparabilityImplicit.java
+++ b/java/daikon/VarComparabilityImplicit.java
@@ -76,7 +76,7 @@ public final class VarComparabilityImplicit extends VarComparability implements 
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
   public boolean equals(
-      /*>>>@GuardSatisfied VarComparabilityImplicit this,*/ final
+      /*>>>@GuardSatisfied VarComparabilityImplicit this,*/
       /*@GuardSatisfied*/ /*@Nullable*/ Object o) {
     if (!(o instanceof VarComparabilityImplicit)) return false;
     return equals((VarComparabilityImplicit) o);
@@ -85,7 +85,7 @@ public final class VarComparabilityImplicit extends VarComparability implements 
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
   public boolean equals(
-      /*>>>@GuardSatisfied VarComparabilityImplicit this,*/ final
+      /*>>>@GuardSatisfied VarComparabilityImplicit this,*/
       /*@GuardSatisfied*/ VarComparabilityImplicit o) {
     return equality_set_ok(o);
   }

--- a/java/daikon/VarInfoAux.java
+++ b/java/daikon/VarInfoAux.java
@@ -300,7 +300,7 @@ public final class VarInfoAux implements Cloneable, Serializable {
   /*@Pure*/
   public boolean equals(
       /*>>>@GuardSatisfied VarInfoAux this,*/
-      final /*@GuardSatisfied*/ /*@Nullable*/ Object o) {
+      /*@GuardSatisfied*/ /*@Nullable*/ Object o) {
     if (o instanceof VarInfoAux) {
       return equals((VarInfoAux) o);
     } else {
@@ -310,8 +310,7 @@ public final class VarInfoAux implements Cloneable, Serializable {
 
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public boolean equals(
-      /*>>>@GuardSatisfied VarInfoAux this,*/ final /*@GuardSatisfied*/ VarInfoAux o) {
+  public boolean equals(/*>>>@GuardSatisfied VarInfoAux this,*//*@GuardSatisfied*/ VarInfoAux o) {
     return this.map.equals(o.map);
   }
 

--- a/java/daikon/chicory/DaikonVariableInfo.java
+++ b/java/daikon/chicory/DaikonVariableInfo.java
@@ -1113,7 +1113,7 @@ public abstract class DaikonVariableInfo
    */
   /*@RequiresNonNull("#1.clazz")*/
   protected void addChildNodes(
-      final ClassInfo cinfo, Class<?> type, String theName, String offset, int depthRemaining) {
+      ClassInfo cinfo, Class<?> type, String theName, String offset, int depthRemaining) {
 
     debug_vars.log("enter addChildNodes:%n");
     debug_vars.log("  name: %s, offset: %s%n", theName, offset);

--- a/java/daikon/diff/MatchCountVisitor.java
+++ b/java/daikon/diff/MatchCountVisitor.java
@@ -119,8 +119,7 @@ public class MatchCountVisitor extends PrintAllVisitor {
 
   /** Returns true if the pair of invariants should be printed **/
   /*@EnsuresNonNullIf(result=true, expression={"#1", "#2"})*/
-  protected static boolean shouldPrint(
-      final /*@Nullable*/ Invariant inv1, final /*@Nullable*/ Invariant inv2) {
+  protected static boolean shouldPrint(/*@Nullable*/ Invariant inv1, /*@Nullable*/ Invariant inv2) {
 
     int rel = DetailedStatisticsVisitor.determineRelationship(inv1, inv2);
     if (rel == DetailedStatisticsVisitor.REL_SAME_JUST1_JUST2) {

--- a/java/daikon/diff/MatchCountVisitor2.java
+++ b/java/daikon/diff/MatchCountVisitor2.java
@@ -143,8 +143,7 @@ public class MatchCountVisitor2 extends PrintAllVisitor {
   // Cannot be static because it uses instance variable "targSet"
   /** Returns true if the pair of invariants should be printed **/
   /*@EnsuresNonNullIf(result=true, expression={"#1", "#2"})*/
-  protected boolean shouldPrint(
-      final /*@Nullable*/ Invariant inv1, final /*@Nullable*/ Invariant inv2) {
+  protected boolean shouldPrint(/*@Nullable*/ Invariant inv1, /*@Nullable*/ Invariant inv2) {
 
     if (inv1 == null || inv2 == null) {
       return false;

--- a/java/daikon/diff/MinusVisitor.java
+++ b/java/daikon/diff/MinusVisitor.java
@@ -42,8 +42,7 @@ public class MinusVisitor extends DepthFirstVisitor {
    * one is null or unjustified, the first invariant should be added.
    **/
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
-  private static boolean shouldAdd(
-      final /*@Nullable*/ Invariant inv1, /*@Nullable*/ Invariant inv2) {
+  private static boolean shouldAdd(/*@Nullable*/ Invariant inv1, /*@Nullable*/ Invariant inv2) {
     return ((inv1 != null) && (inv2 == null));
   }
 

--- a/java/daikon/diff/PptCountVisitor.java
+++ b/java/daikon/diff/PptCountVisitor.java
@@ -184,8 +184,7 @@ public class PptCountVisitor extends PrintAllVisitor {
 
   /** Returns true if the pair of invariants should be printed **/
   /*@EnsuresNonNullIf(result=true, expression={"#1", "#2"})*/
-  protected static boolean shouldPrint(
-      final /*@Nullable*/ Invariant inv1, final /*@Nullable*/ Invariant inv2) {
+  protected static boolean shouldPrint(/*@Nullable*/ Invariant inv1, /*@Nullable*/ Invariant inv2) {
 
     if (inv1 == null || inv2 == null) {
       return false;

--- a/java/daikon/diff/XorVisitor.java
+++ b/java/daikon/diff/XorVisitor.java
@@ -64,8 +64,7 @@ public class XorVisitor extends DepthFirstVisitor {
   }
 
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
-  private static boolean shouldAddInv1(
-      final /*@Nullable*/ Invariant inv1, /*@Nullable*/ Invariant inv2) {
+  private static boolean shouldAddInv1(/*@Nullable*/ Invariant inv1, /*@Nullable*/ Invariant inv2) {
     return ((inv1 != null) && (inv2 == null));
   }
 

--- a/java/daikon/diff/XorVisitor.java
+++ b/java/daikon/diff/XorVisitor.java
@@ -70,8 +70,7 @@ public class XorVisitor extends DepthFirstVisitor {
   }
 
   /*@EnsuresNonNullIf(result=true, expression="#2")*/
-  private static boolean shouldAddInv2(
-      /*@Nullable*/ Invariant inv1, final /*@Nullable*/ Invariant inv2) {
+  private static boolean shouldAddInv2(/*@Nullable*/ Invariant inv1, /*@Nullable*/ Invariant inv2) {
     return ((inv2 != null) && (inv1 == null));
   }
 

--- a/java/daikon/inv/Implication.java
+++ b/java/daikon/inv/Implication.java
@@ -244,7 +244,7 @@ public class Implication extends Joiner {
 
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
-  public boolean isSameInvariant(final Invariant other) {
+  public boolean isSameInvariant(Invariant other) {
     if (other == null) return false;
     if (!(other instanceof Implication)) return false;
     if (iff != ((Implication) other).iff) return false;

--- a/java/daikon/inv/Invariant.java
+++ b/java/daikon/inv/Invariant.java
@@ -42,8 +42,8 @@ import typequals.*;
  * of invariant I(a, b).
  **/
 /*@UsesObjectEquals*/
-/*@Prototype*/
-public abstract class Invariant implements Serializable, Cloneable // but don't YOU clone it
+/*@Prototype*/ public abstract class Invariant
+    implements Serializable, Cloneable // but don't YOU clone it
 {
   // We are Serializable, so we specify a version to allow changes to
   // method signatures without breaking serialization.  If you add or

--- a/java/daikon/suppress/NIS.java
+++ b/java/daikon/suppress/NIS.java
@@ -933,7 +933,7 @@ public class NIS {
     /*@Pure*/
     public boolean equals(
         /*>>>@GuardSatisfied SupInv this,*/
-        final /*@GuardSatisfied*/ /*@Nullable*/ Object obj) {
+        /*@GuardSatisfied*/ /*@Nullable*/ Object obj) {
       if (!(obj instanceof SupInv)) return false;
 
       // Class and variables must match

--- a/java/daikon/suppress/NISuppressee.java
+++ b/java/daikon/suppress/NISuppressee.java
@@ -188,7 +188,7 @@ public class NISuppressee {
    */
   /*@RequiresNonNull("#2.equality_view")*/
   public List<NIS.SupInv> find_all(
-      VarInfo[] vis, final PptTopLevel ppt, /*@Nullable*/ Invariant /*@Nullable*/ [] cinvs) {
+      VarInfo[] vis, PptTopLevel ppt, /*@Nullable*/ Invariant /*@Nullable*/ [] cinvs) {
 
     List<NIS.SupInv> created_list = new ArrayList<NIS.SupInv>();
 

--- a/java/daikon/tools/jtb/Annotation.java
+++ b/java/daikon/tools/jtb/Annotation.java
@@ -274,7 +274,8 @@ public class Annotation {
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
   public boolean equals(
-      /*>>>@GuardSatisfied Annotation this,*/ final /*@GuardSatisfied*/ /*@Nullable*/ Object o) {
+      /*>>>@GuardSatisfied Annotation this,*/
+      /*@GuardSatisfied*/ /*@Nullable*/ Object o) {
     if (o == null) {
       return false;
     }

--- a/java/daikon/tools/runtimechecker/Property.java
+++ b/java/daikon/tools/runtimechecker/Property.java
@@ -155,7 +155,8 @@ public class Property implements Serializable {
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
   public boolean equals(
-      /*>>>@GuardSatisfied Property this,*/ final /*@GuardSatisfied*/ /*@Nullable*/ Object o) {
+      /*>>>@GuardSatisfied Property this,*/
+      /*@GuardSatisfied*/ /*@Nullable*/ Object o) {
     if (o == null) {
       return false;
     }

--- a/java/daikon/tools/runtimechecker/Violation.java
+++ b/java/daikon/tools/runtimechecker/Violation.java
@@ -213,7 +213,8 @@ public class Violation implements Serializable {
   /*@EnsuresNonNullIf(result=true, expression="#1")*/
   /*@Pure*/
   public boolean equals(
-      /*>>>@GuardSatisfied Violation this,*/ final /*@GuardSatisfied*/ /*@Nullable*/ Object o) {
+      /*>>>@GuardSatisfied Violation this,*/
+      /*@GuardSatisfied*/ /*@Nullable*/ Object o) {
     if (o == null) {
       return false;
     }


### PR DESCRIPTION
(Do not merge until typetools/checker-framework#817  has been merged)

Because of typetools/checker-framework#767, `flowexpr.parameter.not.final` errors were issued even when the parameter was effectively final.  Pull request typetools/checker-framework#817 fixes this issue.  

I searched for commits containing final and revert the commits (1ed573e, d6e8ae9, 1581214) that only added final. 

