### PR TITLE
Add Nullness Checker annotations

### DIFF
--- a/java/daikon/Daikon.java
+++ b/java/daikon/Daikon.java
@@ -1818,7 +1818,7 @@ public final class Daikon {
   ///////////////////////////////////////////////////////////////////////////
   // Read decls, dtrace, etc. files
 
-  /*@RequiresNonNull("fileio_progress")*/
+  /*@RequiresNonNull({"fileio_progress", "NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   // set in mainHelper
   private static PptMap load_decls_files(Set<File> decl_files) {
     stopwatch.reset();

--- a/java/daikon/Daikon.java
+++ b/java/daikon/Daikon.java
@@ -2278,6 +2278,7 @@ public final class Daikon {
   /**
    * Initialize NIS suppression
    */
+  /*@EnsuresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void setup_NISuppression() {
     NIS.init_ni_suppression();
   }

--- a/java/daikon/FileIO.java
+++ b/java/daikon/FileIO.java
@@ -13,6 +13,7 @@ import daikon.config.Configuration;
 import daikon.derive.ValueAndModified;
 import daikon.diff.InvMap;
 import daikon.inv.Invariant;
+import daikon.suppress.NIS;
 import java.io.*;
 import java.net.*;
 import java.text.*;
@@ -1805,6 +1806,10 @@ public final class FileIO {
       return;
     }
 
+    // Workaround for Checker Framework issue #862
+    // https://github.com/typetools/checker-framework/issues/862
+    // Use NIS so that it is in scope to check the precondition below.
+    Object o = NIS.suppressor_map;
     ppt.add_bottom_up(vt, 1);
 
     if (debugVars.isLoggable(Level.FINE)) {

--- a/java/daikon/FileIO.java
+++ b/java/daikon/FileIO.java
@@ -290,6 +290,7 @@ public final class FileIO {
    * listed in the argument; connection information (controlling
    * variables and entry ppts) is set correctly upon return.
    **/
+  /*@RequiresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static PptMap read_declaration_files(Collection<File> files) throws IOException {
     PptMap all_ppts = new PptMap();
     // Read all decls, creating PptTopLevels and VarInfos
@@ -304,6 +305,7 @@ public final class FileIO {
   }
 
   /** Read one decls file; add it to all_ppts. **/
+  /*@RequiresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void read_declaration_file(File filename, PptMap all_ppts) throws IOException {
     if (Daikon.using_DaikonSimple) {
       Processor processor = new DaikonSimple.SimpleProcessor();
@@ -965,6 +967,7 @@ public final class FileIO {
    *
    * @see #read_data_trace_file(String,PptMap,Processor,boolean,boolean)
    **/
+  /*@RequiresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void read_data_trace_files(
       Collection<String> files, PptMap all_ppts, Processor processor, boolean ppts_may_be_new)
       throws IOException {
@@ -1135,7 +1138,7 @@ public final class FileIO {
      * {@link FileIO#process_sample(PptMap, PptTopLevel, ValueTuple, Integer)}.
      * @see FileIO#process_sample(PptMap, PptTopLevel, ValueTuple, Integer)
      */
-    /*@RequiresNonNull("FileIO.data_trace_state")*/
+    /*@RequiresNonNull({"FileIO.data_trace_state", "NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
     public void process_sample(
         PptMap all_ppts, PptTopLevel ppt, ValueTuple vt, /*@Nullable*/ Integer nonce) {
       FileIO.process_sample(all_ppts, ppt, vt, nonce);
@@ -1404,6 +1407,7 @@ public final class FileIO {
    * {@link FileIO#process_sample(PptMap, PptTopLevel, ValueTuple, Integer)}
    * on each record, and ignores records other than samples.
    **/
+  /*@RequiresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void read_data_trace_file(String filename, PptMap all_ppts) throws IOException {
     Processor processor = new Processor();
     read_data_trace_file(filename, all_ppts, processor, false, true);
@@ -1414,6 +1418,7 @@ public final class FileIO {
    * imply) from .dtrace file.  For each record read from the file, passes
    * the record to a method of the processor.
    **/
+  /*@RequiresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void read_data_trace_file(
       String filename,
       PptMap all_ppts,
@@ -1750,7 +1755,7 @@ public final class FileIO {
    * supply it to the program point for flowing.
    * @param vt trace data only; modified by side effect to add derived vars
    **/
-  /*@RequiresNonNull("FileIO.data_trace_state")*/
+  /*@RequiresNonNull({"FileIO.data_trace_state", "NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void process_sample(
       PptMap all_ppts, PptTopLevel ppt, ValueTuple vt, /*@Nullable*/ Integer nonce) {
 

--- a/java/daikon/FileIO.java
+++ b/java/daikon/FileIO.java
@@ -1814,7 +1814,7 @@ public final class FileIO {
     // Workaround for Checker Framework issue #862
     // https://github.com/typetools/checker-framework/issues/862
     // Use NIS so that it is in scope to check the precondition below.
-    Object o = NIS.suppressor_map;
+    Object dummy = NIS.suppressor_map;
     ppt.add_bottom_up(vt, 1);
 
     if (debugVars.isLoggable(Level.FINE)) {

--- a/java/daikon/suppress/NIS.java
+++ b/java/daikon/suppress/NIS.java
@@ -719,6 +719,7 @@ public class NIS {
    * other invariants, they must be added to each of set of comparable
    * antecedents.
    */
+  /*@RequiresNonNull("NIS.suppressor_map")*/
   static void merge_always_comparable(Map<VarComparability, Antecedents> comp_ants) {
 
     // Find the antecedents that are always comparable (if any)
@@ -1059,6 +1060,7 @@ public class NIS {
      * invariants are added to the beginning of the list, non-falsified
      * ones to the end.
      */
+    /*@RequiresNonNull("NIS.suppressor_map")*/
     public void add(Invariant inv) {
 
       // Only possible antecedents need to be added
@@ -1093,6 +1095,7 @@ public class NIS {
     /**
      * Adds all of the antecedents specified to the lists for their class
      */
+    /*@RequiresNonNull("NIS.suppressor_map")*/
     public void add(Antecedents ants) {
 
       for (List<Invariant> invs : ants.antecedent_map.values()) {

--- a/java/daikon/suppress/NIS.java
+++ b/java/daikon/suppress/NIS.java
@@ -874,7 +874,9 @@ public class NIS {
   /**
    * Returns true if the specified class is an antecedent in any NI suppression
    */
-  /*@RequiresNonNull("suppressor_map")*/
+  //Use class name in front of static field to work around Checker Framework issue 764
+  // https://github.com/typetools/checker-framework/issues/764
+  /*@RequiresNonNull("NIS.suppressor_map")*/
   /*@Pure*/
   public static boolean is_suppressor(Class<? extends Invariant> cls) {
     return (suppressor_map.containsKey(cls));

--- a/java/daikon/suppress/NIS.java
+++ b/java/daikon/suppress/NIS.java
@@ -875,8 +875,6 @@ public class NIS {
   /**
    * Returns true if the specified class is an antecedent in any NI suppression
    */
-  //Use class name in front of static field to work around Checker Framework issue 764
-  // https://github.com/typetools/checker-framework/issues/764
   /*@RequiresNonNull("NIS.suppressor_map")*/
   /*@Pure*/
   public static boolean is_suppressor(Class<? extends Invariant> cls) {

--- a/java/daikon/tools/DtraceDiff.java
+++ b/java/daikon/tools/DtraceDiff.java
@@ -233,6 +233,7 @@ public class DtraceDiff {
     dtraceDiff(declsfile1, dtracefile1, declsfile2, dtracefile2);
   }
 
+  /*@RequiresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void dtraceDiff(
       Set<File> declsfile1, String dtracefile1, Set<File> declsfile2, String dtracefile2) {
 


### PR DESCRIPTION
Adds work arounds for  typetools/checker-framework#764 and typetools/checker-framework#862.  Also, adds `@RequiresNonNull` and `@EnsuresNonNull` annotations that should have appear before, but because of the issues mentioned above, the Nullness Checker did not issue errors.