### PR TITLE
Revert "Add Nullness Checker annotations"

### DIFF
--- a/java/daikon/Daikon.java
+++ b/java/daikon/Daikon.java
@@ -1818,7 +1818,7 @@ public final class Daikon {
   ///////////////////////////////////////////////////////////////////////////
   // Read decls, dtrace, etc. files
 
-  /*@RequiresNonNull({"fileio_progress", "NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
+  /*@RequiresNonNull("fileio_progress")*/
   // set in mainHelper
   private static PptMap load_decls_files(Set<File> decl_files) {
     stopwatch.reset();
@@ -2278,7 +2278,6 @@ public final class Daikon {
   /**
    * Initialize NIS suppression
    */
-  /*@EnsuresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void setup_NISuppression() {
     NIS.init_ni_suppression();
   }

--- a/java/daikon/FileIO.java
+++ b/java/daikon/FileIO.java
@@ -13,7 +13,6 @@ import daikon.config.Configuration;
 import daikon.derive.ValueAndModified;
 import daikon.diff.InvMap;
 import daikon.inv.Invariant;
-import daikon.suppress.NIS;
 import java.io.*;
 import java.net.*;
 import java.text.*;
@@ -290,7 +289,6 @@ public final class FileIO {
    * listed in the argument; connection information (controlling
    * variables and entry ppts) is set correctly upon return.
    **/
-  /*@RequiresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static PptMap read_declaration_files(Collection<File> files) throws IOException {
     PptMap all_ppts = new PptMap();
     // Read all decls, creating PptTopLevels and VarInfos
@@ -305,7 +303,6 @@ public final class FileIO {
   }
 
   /** Read one decls file; add it to all_ppts. **/
-  /*@RequiresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void read_declaration_file(File filename, PptMap all_ppts) throws IOException {
     if (Daikon.using_DaikonSimple) {
       Processor processor = new DaikonSimple.SimpleProcessor();
@@ -967,7 +964,6 @@ public final class FileIO {
    *
    * @see #read_data_trace_file(String,PptMap,Processor,boolean,boolean)
    **/
-  /*@RequiresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void read_data_trace_files(
       Collection<String> files, PptMap all_ppts, Processor processor, boolean ppts_may_be_new)
       throws IOException {
@@ -1138,7 +1134,7 @@ public final class FileIO {
      * {@link FileIO#process_sample(PptMap, PptTopLevel, ValueTuple, Integer)}.
      * @see FileIO#process_sample(PptMap, PptTopLevel, ValueTuple, Integer)
      */
-    /*@RequiresNonNull({"FileIO.data_trace_state", "NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
+    /*@RequiresNonNull("FileIO.data_trace_state")*/
     public void process_sample(
         PptMap all_ppts, PptTopLevel ppt, ValueTuple vt, /*@Nullable*/ Integer nonce) {
       FileIO.process_sample(all_ppts, ppt, vt, nonce);
@@ -1407,7 +1403,6 @@ public final class FileIO {
    * {@link FileIO#process_sample(PptMap, PptTopLevel, ValueTuple, Integer)}
    * on each record, and ignores records other than samples.
    **/
-  /*@RequiresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void read_data_trace_file(String filename, PptMap all_ppts) throws IOException {
     Processor processor = new Processor();
     read_data_trace_file(filename, all_ppts, processor, false, true);
@@ -1418,7 +1413,6 @@ public final class FileIO {
    * imply) from .dtrace file.  For each record read from the file, passes
    * the record to a method of the processor.
    **/
-  /*@RequiresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void read_data_trace_file(
       String filename,
       PptMap all_ppts,
@@ -1755,7 +1749,7 @@ public final class FileIO {
    * supply it to the program point for flowing.
    * @param vt trace data only; modified by side effect to add derived vars
    **/
-  /*@RequiresNonNull({"FileIO.data_trace_state", "NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
+  /*@RequiresNonNull("FileIO.data_trace_state")*/
   public static void process_sample(
       PptMap all_ppts, PptTopLevel ppt, ValueTuple vt, /*@Nullable*/ Integer nonce) {
 
@@ -1811,10 +1805,6 @@ public final class FileIO {
       return;
     }
 
-    // Workaround for Checker Framework issue #862
-    // https://github.com/typetools/checker-framework/issues/862
-    // Use NIS so that it is in scope to check the precondition below.
-    Object dummy = NIS.suppressor_map;
     ppt.add_bottom_up(vt, 1);
 
     if (debugVars.isLoggable(Level.FINE)) {

--- a/java/daikon/suppress/NIS.java
+++ b/java/daikon/suppress/NIS.java
@@ -719,7 +719,6 @@ public class NIS {
    * other invariants, they must be added to each of set of comparable
    * antecedents.
    */
-  /*@RequiresNonNull("NIS.suppressor_map")*/
   static void merge_always_comparable(Map<VarComparability, Antecedents> comp_ants) {
 
     // Find the antecedents that are always comparable (if any)
@@ -875,7 +874,7 @@ public class NIS {
   /**
    * Returns true if the specified class is an antecedent in any NI suppression
    */
-  /*@RequiresNonNull("NIS.suppressor_map")*/
+  /*@RequiresNonNull("suppressor_map")*/
   /*@Pure*/
   public static boolean is_suppressor(Class<? extends Invariant> cls) {
     return (suppressor_map.containsKey(cls));
@@ -1058,7 +1057,6 @@ public class NIS {
      * invariants are added to the beginning of the list, non-falsified
      * ones to the end.
      */
-    /*@RequiresNonNull("NIS.suppressor_map")*/
     public void add(Invariant inv) {
 
       // Only possible antecedents need to be added
@@ -1093,7 +1091,6 @@ public class NIS {
     /**
      * Adds all of the antecedents specified to the lists for their class
      */
-    /*@RequiresNonNull("NIS.suppressor_map")*/
     public void add(Antecedents ants) {
 
       for (List<Invariant> invs : ants.antecedent_map.values()) {

--- a/java/daikon/tools/DtraceDiff.java
+++ b/java/daikon/tools/DtraceDiff.java
@@ -233,7 +233,6 @@ public class DtraceDiff {
     dtraceDiff(declsfile1, dtracefile1, declsfile2, dtracefile2);
   }
 
-  /*@RequiresNonNull({"NIS.suppressor_map", "NIS.suppressor_map_suppression_count", "NIS.all_suppressions"})*/
   public static void dtraceDiff(
       Set<File> declsfile1, String dtracefile1, Set<File> declsfile2, String dtracefile2) {
 


### PR DESCRIPTION
Reverts codespecs/daikon#63

This passed on my machine, but failed both in [Travis](https://travis-ci.org/typetests/daikon-typecheck/jobs/148126225)  and [Jenkins](http://tern.cs.washington.edu:8080/job/daikon-typecheck/jdk=Local_jdk8u/1044/console)  I'm reverting this change and will instead just suppress the warnings issued because of issue typetools/checker-framework#764 and typetools/checker-framework#862