### PR TITLE
Merge after Checker Framework Issue 674 is fixed

### DIFF
--- a/java/daikon/suppress/NIS.java
+++ b/java/daikon/suppress/NIS.java
@@ -1059,12 +1059,8 @@ public class NIS {
      */
     public void add(Invariant inv) {
 
-      // See Checker Framework Issue 767
-      // https://github.com/typetools/checker-framework/issues/764
-      @SuppressWarnings("contracts.precondition.not.satisfied")
-      boolean is_suppressor = is_suppressor(inv.getClass());
       // Only possible antecedents need to be added
-      if (!is_suppressor) return;
+      if (!is_suppressor(inv.getClass())) return;
 
       // Only antecedents comparable to this one should be added
       assert VarComparability.comparable(inv.get_comparability(), comparability);

--- a/java/daikon/suppress/NIS.java
+++ b/java/daikon/suppress/NIS.java
@@ -719,6 +719,7 @@ public class NIS {
    * other invariants, they must be added to each of set of comparable
    * antecedents.
    */
+  /*@RequiresNonNull("NIS.suppressor_map")*/
   static void merge_always_comparable(Map<VarComparability, Antecedents> comp_ants) {
 
     // Find the antecedents that are always comparable (if any)
@@ -1057,6 +1058,7 @@ public class NIS {
      * invariants are added to the beginning of the list, non-falsified
      * ones to the end.
      */
+    /*@RequiresNonNull("NIS.suppressor_map")*/
     public void add(Invariant inv) {
 
       // Only possible antecedents need to be added
@@ -1091,6 +1093,7 @@ public class NIS {
     /**
      * Adds all of the antecedents specified to the lists for their class
      */
+    /*@RequiresNonNull("NIS.suppressor_map")*/
     public void add(Antecedents ants) {
 
       for (List<Invariant> invs : ants.antecedent_map.values()) {


### PR DESCRIPTION
Remove warning suppression that is no long need once typetools/checker-framework#674 is fixed.  (Issue is fixed in pull request typetools/checker-framework#914)