### PR TITLE
Revert "Tweak @SuppressWarnings key"

### DIFF
--- a/java/daikon/PptSlice.java
+++ b/java/daikon/PptSlice.java
@@ -78,7 +78,8 @@ public abstract class PptSlice extends Ppt {
   }
 
   /*@SideEffectFree*/
-  @SuppressWarnings("override.receiver.invalid") // see comment on overridden definition in Ppt
+  @SuppressWarnings(
+      "initialization:override.receiver.invalid") // see comment on overridden definition in Ppt
   public final String name(
       /*>>>@GuardSatisfied @UnknownInitialization(PptSlice.class) @Raw(PptSlice.class) PptSlice this*/) {
     return parent.name + varNames(var_infos);


### PR DESCRIPTION
This reverts commit 78894eacffb34a33c434a9d6ccbd5ccda7a7e278.

(I think it was a fluke that daikon-typecheck failed with the less specific warning suppression.) 