### PR TITLE
Suppress cast.unsafe warnings issued by the Value Checker.

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -852,7 +852,8 @@ CHECKER_ARGS ?= -AprintErrorStack -Xmaxerrs 10000 -Xmaxwarns 10000 -XDignore.sym
 ## All of the following targets need to depend on "compile".
 
 # Just check that the Index Checker doesn't crash -- suppress type-checking errors.
-JAVAC_INDEX_ARGS = -processor org.checkerframework.checker.index.IndexChecker -implicit:class -Xlint:-processing -AskipDefs='${INDEX_SKIPDEFS}' -AassumeAssertionsAreEnabled -AsuppressWarnings=index
+# Also suppressing cast.unsafe issued by the Value Checker see: https://github.com/typetools/checker-framework/issues/1264
+JAVAC_INDEX_ARGS = -processor org.checkerframework.checker.index.IndexChecker -implicit:class -Xlint:-processing -AskipDefs='${INDEX_SKIPDEFS}' -AassumeAssertionsAreEnabled -AsuppressWarnings="index,value:cast.unsafe"
 # JAVAC_INTERNING_ARGS = -processor org.checkerframework.checker.interning.InterningChecker -implicit:class -Xlint:-processing
 JAVAC_INTERNING_ARGS = -processor org.checkerframework.checker.interning.InterningChecker -Alint=-dotequals -implicit:class -Xlint:-processing -AskipDefs='${INTERNING_SKIPDEFS}'
 JAVAC_SIGNATURE_ARGS = -processor org.checkerframework.checker.signature.SignatureChecker -implicit:class -Xlint:-processing -AskipDefs='${ALLSYSTEMS_SKIPDEFS}'


### PR DESCRIPTION
The warnings are false positives caused by typetools/checker-framework#1264.