### PR TITLE
correct java 8 annotation processing

### DIFF
--- a/java/daikon/dcomp/DCInstrument.java
+++ b/java/daikon/dcomp/DCInstrument.java
@@ -427,9 +427,16 @@ public class DCInstrument extends InstructionListUtils {
         }
 
         remove_local_variable_type_table(mg);
-        // Remove all RuntimeAnnotations (if any), as they do not apply
-        // to the instrumented version of the method.
-        mg.removeAnnotationEntries();
+
+        // We do not want to copy the @HotSpotIntrinsicCandidate annotations from
+        // the normal methods to our instrumented methods.  It doesn't cause an
+        // execution problem but will produce a massive number of warnings.
+        // Unfortunately, BCEL does not have the methods necessary to do this,
+        // so we hit it with a huge hammer and remove all the annotations.
+        // This annotation was added post Java 8.
+        if (BcelUtil.javaVersion > 8) {
+          mg.removeAnnotationEntries();
+        }
 
         if (!BcelUtil.isMain(mg) && !BcelUtil.isClinit(mg)) {
           // doubling
@@ -638,9 +645,11 @@ public class DCInstrument extends InstructionListUtils {
         }
 
         remove_local_variable_type_table(mg);
-        // Remove all RuntimeAnnotations (if any), as they do not apply
-        // to the instrumented version of the method.
-        mg.removeAnnotationEntries();
+
+        if (BcelUtil.javaVersion > 8) {
+          // see comments in instrument();
+          mg.removeAnnotationEntries();
+        }
 
         if (!BcelUtil.isMain(mg) && !BcelUtil.isClinit(mg)) {
           // doubling
@@ -834,9 +843,10 @@ public class DCInstrument extends InstructionListUtils {
 
         remove_local_variable_type_table(mg);
 
-        // Remove all RuntimeAnnotations (if any), as they do not apply
-        // to the instrumented version of the method.
-        mg.removeAnnotationEntries();
+        if (BcelUtil.javaVersion > 8) {
+          // see comments in instrument();
+          mg.removeAnnotationEntries();
+        }
 
         if (initial_jdk_instrument && has_code) {
           // mark this method as needing to be reinstrumented at runtime
@@ -989,9 +999,10 @@ public class DCInstrument extends InstructionListUtils {
 
         remove_local_variable_type_table(mg);
 
-        // Remove all RuntimeAnnotations (if any), as they do not apply
-        // to the instrumented version of the method.
-        mg.removeAnnotationEntries();
+        if (BcelUtil.javaVersion > 8) {
+          // see comments in instrument();
+          mg.removeAnnotationEntries();
+        }
 
         if (initial_jdk_instrument && has_code) {
           // mark this method as needing to be reinstrumented at runtime

--- a/java/daikon/dcomp/Premain.java
+++ b/java/daikon/dcomp/Premain.java
@@ -72,15 +72,36 @@ public class Premain {
   protected static Set<String> problem_methods =
       new HashSet<>(
           Arrays.asList(
-              // The following methods call Reflection.getCallerClass().
+              // The following methods call sun.reflect.Reflection.getCallerClass().
               // These methods are annotated with @CallerSensitive to
               // indicate 'skip me when looking at call stack'.
               // When we create the instrumented version of these methods we
               // should include this annotation.  However, BCEL does not support
               // this at this time.  So for now, we do not instrument these methods.
-              // (There are many more in the JDK sources, but so far no problems.)
+              // Initially, we just had a couple methods listed, but it turns out
+              // that the junit tool references a large number of these methods.
               "java.lang.Class.forName",
               "java.lang.Class.newInstance",
+              "java.lang.Class.getClassLoader",
+              "java.lang.Class.getEnclosingMethod",
+              "java.lang.Class.getDeclaringClass",
+              "java.lang.Class.getEnclosingClass",
+              "java.lang.Class.getClasses",
+              "java.lang.Class.getField",
+              "java.lang.Class.getFields",
+              "java.lang.Class.getMethod",
+              "java.lang.Class.getMethods",
+              "java.lang.Class.getConstructor",
+              "java.lang.Class.getConstructors",
+              "java.lang.Class.getDeclaredClasses",
+              "java.lang.Class.getDeclaredField",
+              "java.lang.Class.getDeclaredFields",
+              "java.lang.Class.getDeclaredMethod",
+              "java.lang.Class.getDeclaredMethods",
+              "java.lang.Class.getDeclaredConstructor",
+              "java.lang.Class.getDeclaredConstructors",
+              "java.util.ResourceBundle.getBundle",
+              "java.util.ResourceBundle.clearCache",
 
               // The below entries are temporary, until the bugs are fixed.
 


### PR DESCRIPTION
allow java 8 annotations to be copied to instrumented methods.
increase list of problem_methods for java 11