### PR TITLE
Suppress instanceof annotation check warnings

### DIFF
--- a/java/daikon/inv/unary/OneOf.java.jpp
+++ b/java/daikon/inv/unary/OneOf.java.jpp
@@ -2118,9 +2118,9 @@ public String format_csharp_contract(@GuardSatisfied ONEOFSCALAR this) {
     if (num_elts == 0) {
       return false;
     }
-    @SuppressWarnings("allcheckers:operand.instanceof.subtype") //  Warnings are suppressed because only the data type of the state needs to be checked and not the annotations
-    boolean stateTypeMatch = !(state instanceof INT[]);
-    if (stateTypeMatch) {
+    @SuppressWarnings("allcheckers:instanceof.unsafe") //  Only the data type of the state needs to be checked and the annotations must be ignored, hence, the qualifier is irrelevant
+    boolean stateIsNotArray = !(state instanceof INT[]);
+    if (stateIsNotArray) {
       System.out.println("state is of class '" + state.getClass().getName()
                           + "'");
     }

--- a/java/daikon/inv/unary/OneOf.java.jpp
+++ b/java/daikon/inv/unary/OneOf.java.jpp
@@ -2118,7 +2118,6 @@ public String format_csharp_contract(@GuardSatisfied ONEOFSCALAR this) {
     if (num_elts == 0) {
       return false;
     }
-    @SuppressWarnings("allcheckers:instanceof.unsafe") //  Only the data type of the state needs to be checked and the annotations must be ignored, hence, the qualifier is irrelevant
     boolean stateIsNotArray = !(state instanceof INTARRAY);
     if (stateIsNotArray) {
       // Daikon is about to crash.  Produce some debugging output.

--- a/java/daikon/inv/unary/OneOf.java.jpp
+++ b/java/daikon/inv/unary/OneOf.java.jpp
@@ -2113,7 +2113,7 @@ public String format_csharp_contract(@GuardSatisfied ONEOFSCALAR this) {
    * example if x = 1 and the state contains 1 and 2, true will be returned.
    */
   @Override
-  @SuppressWarnings("interning:operand.instanceof.subtype")
+  @SuppressWarnings("allcheckers:operand.instanceof.subtype")
   public boolean state_match(Object state) {
 
     if (num_elts == 0) {

--- a/java/daikon/inv/unary/OneOf.java.jpp
+++ b/java/daikon/inv/unary/OneOf.java.jpp
@@ -2113,6 +2113,7 @@ public String format_csharp_contract(@GuardSatisfied ONEOFSCALAR this) {
    * example if x = 1 and the state contains 1 and 2, true will be returned.
    */
   @Override
+  @SuppressWarnings("interning:operand.instanceof.subtype")
   public boolean state_match(Object state) {
 
     if (num_elts == 0) {

--- a/java/daikon/inv/unary/OneOf.java.jpp
+++ b/java/daikon/inv/unary/OneOf.java.jpp
@@ -2113,14 +2113,14 @@ public String format_csharp_contract(@GuardSatisfied ONEOFSCALAR this) {
    * example if x = 1 and the state contains 1 and 2, true will be returned.
    */
   @Override
-  @SuppressWarnings("allcheckers:operand.instanceof.subtype")
   public boolean state_match(Object state) {
 
     if (num_elts == 0) {
       return false;
     }
-
-    if (!(state instanceof INT[])) {
+    @SuppressWarnings("allcheckers:operand.instanceof.subtype")
+    boolean stateTypeMatch = !(state instanceof INT[]); //  Warnings are suppressed because only the data type of the state needs to be checked and not the annotations
+    if (stateTypeMatch) {
       System.out.println("state is of class '" + state.getClass().getName()
                           + "'");
     }

--- a/java/daikon/inv/unary/OneOf.java.jpp
+++ b/java/daikon/inv/unary/OneOf.java.jpp
@@ -2118,8 +2118,8 @@ public String format_csharp_contract(@GuardSatisfied ONEOFSCALAR this) {
     if (num_elts == 0) {
       return false;
     }
-    @SuppressWarnings("allcheckers:operand.instanceof.subtype")
-    boolean stateTypeMatch = !(state instanceof INT[]); //  Warnings are suppressed because only the data type of the state needs to be checked and not the annotations
+    @SuppressWarnings("allcheckers:operand.instanceof.subtype") //  Warnings are suppressed because only the data type of the state needs to be checked and not the annotations
+    boolean stateTypeMatch = !(state instanceof INT[]);
     if (stateTypeMatch) {
       System.out.println("state is of class '" + state.getClass().getName()
                           + "'");


### PR DESCRIPTION
Adding a ```@SuppressWarnings("allcheckers:operand.instanceof.subtype")``` line in OneOf.java.jpp to just check the data type (and not the annotations) of the ```state``` variable in the ```boolean state_match()``` method. This was done to bypass the ```instanceof``` error and pass the daikon tests in the pull request #3481 in typetools/checker-framework (https://github.com/typetools/checker-framework/pull/3481).