### PR TITLE
In contract annotations use fully-qualified class names when needed

### DIFF
--- a/java/daikon/Daikon.java
+++ b/java/daikon/Daikon.java
@@ -188,6 +188,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import org.checkerframework.checker.interning.qual.Interned;
+import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.KeyFor;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -2238,7 +2239,6 @@ public final class Daikon {
    * have been loaded, all of the program points have been setup, and candidate invariants have been
    * instantiated. This routine processes data to falsify the candidate invariants.
    */
-  @SuppressWarnings("nullness:contracts.precondition.not.satisfied") // private field
   @RequiresNonNull("fileio_progress")
   // set in mainHelper
   private static void process_data(PptMap all_ppts, Set<String> dtrace_files) {
@@ -2496,6 +2496,12 @@ public final class Daikon {
   }
 
   /** Initialize NIS suppression. */
+  @EnsuresNonNull({
+    "daikon.suppress.NIS.suppressor_map",
+    "daikon.suppress.NIS.suppressor_map_suppression_count",
+    "daikon.suppress.NIS.all_suppressions",
+    "daikon.suppress.NIS.suppressor_proto_invs"
+  })
   public static void setup_NISuppression() {
     NIS.init_ni_suppression();
   }
@@ -2660,8 +2666,7 @@ public final class Daikon {
    * Undoes the invariants suppressed for the dynamic constant, suppression and equality set
    * optimizations (should yield the same invariants as the simple incremental algorithm.
    */
-  @SuppressWarnings("flowexpr.parse.error") // private field
-  @RequiresNonNull({"NIS.all_suppressions", "NIS.suppressor_map"})
+  @RequiresNonNull({"daikon.suppress.NIS.all_suppressions", "daikon.suppress.NIS.suppressor_map"})
   public static void undoOpts(PptMap all_ppts) {
 
     // undo suppressions

--- a/java/daikon/DynamicConstants.java
+++ b/java/daikon/DynamicConstants.java
@@ -1027,7 +1027,7 @@ public class DynamicConstants implements Serializable {
    * (default is on), only unary and binary invariants that can be suppressors in NIS suppressions
    * are created.
    */
-  @RequiresNonNull("NIS.suppressor_proto_invs")
+  @RequiresNonNull("daikon.suppress.NIS.suppressor_proto_invs")
   public List<PptSlice> create_constant_invs() {
 
     // Turn off track logging so that we don't get voluminous messages

--- a/java/daikon/FileIO.java
+++ b/java/daikon/FileIO.java
@@ -1801,10 +1801,7 @@ public final class FileIO {
       return;
     }
 
-    @SuppressWarnings({
-      "UnusedVariable",
-      "nullness:flowexpr.parse.error"
-    }) // https://tinyurl.com/cfissue/862
+    @SuppressWarnings({"UnusedVariable", "nullness:contracts.precondition.not.satisfied"})
     Object dummy = ppt.add_bottom_up(vt, 1);
 
     if (debugVars.isLoggable(Level.FINE)) {

--- a/java/daikon/PptSlice.java
+++ b/java/daikon/PptSlice.java
@@ -176,7 +176,7 @@ public abstract class PptSlice extends Ppt {
   abstract List<Invariant> add(ValueTuple full_vt, int count);
 
   /** Removes any falsified invariants from our list. */
-  @RequiresNonNull("NIS.suppressor_map")
+  @RequiresNonNull("daikon.suppress.NIS.suppressor_map")
   protected void remove_falsified() {
 
     // Remove the dead invariants

--- a/java/daikon/PptTopLevel.java
+++ b/java/daikon/PptTopLevel.java
@@ -999,14 +999,11 @@ public class PptTopLevel extends Ppt {
    * @param count the number of samples that vt represents
    * @return the set of all invariants weakened or falsified by this sample
    */
-  @SuppressWarnings({
-    "flowexpr.parse.error",
-    "nullness:contracts.precondition.not.satisfied"
-  }) // private field
   @RequiresNonNull({
-    "NIS.suppressor_map",
-    "NIS.suppressor_map_suppression_count",
-    "NIS.all_suppressions"
+    "daikon.suppress.NIS.suppressor_map",
+    "daikon.suppress.NIS.suppressor_map_suppression_count",
+    "daikon.suppress.NIS.all_suppressions",
+    "daikon.suppress.NIS.suppressor_proto_invs"
   })
   public @Nullable Set<Invariant> add_bottom_up(ValueTuple vt, int count) {
     // Doable, but commented out for efficiency
@@ -1412,7 +1409,7 @@ public class PptTopLevel extends Ppt {
   }
 
   /** Debug print to the specified logger information about each invariant at this ppt. */
-  @RequiresNonNull("NIS.suppressor_map")
+  @RequiresNonNull("daikon.suppress.NIS.suppressor_map")
   public void debug_invs(Logger log) {
 
     for (Iterator<PptSlice> i = views_iterator(); i.hasNext(); ) {

--- a/java/daikon/PrintInvariants.java
+++ b/java/daikon/PrintInvariants.java
@@ -307,7 +307,6 @@ public final class PrintInvariants {
    * This does the work of {@link #main(String[])}, but it never calls System.exit, so it is
    * appropriate to be called progrmmatically.
    */
-  @SuppressWarnings("nullness:contracts.precondition.not.satisfied") // private field
   public static void mainHelper(String[] args)
       throws FileNotFoundException, StreamCorruptedException, OptionalDataException, IOException,
           ClassNotFoundException {
@@ -1681,8 +1680,7 @@ public final class PrintInvariants {
     }
   }
 
-  @SuppressWarnings("flowexpr.parse.error") // private field
-  @RequiresNonNull({"NIS.all_suppressions", "NIS.suppressor_map"})
+  @RequiresNonNull({"daikon.suppress.NIS.all_suppressions", "daikon.suppress.NIS.suppressor_map"})
   public static void print_true_inv_cnt(PptMap ppts) {
 
     // Count printable invariants

--- a/java/daikon/diff/InvMap.java
+++ b/java/daikon/diff/InvMap.java
@@ -134,14 +134,14 @@ public class InvMap implements Serializable {
   }
 
   /** Include FileIO.new_decl_format in the stream */
-  @RequiresNonNull("FileIO.new_decl_format")
+  @RequiresNonNull("daikon.FileIO.new_decl_format")
   private void writeObject(ObjectOutputStream oos) throws IOException {
     oos.defaultWriteObject();
     oos.writeObject(FileIO.new_decl_format);
   }
 
   /** Serialize pptmap and FileIO.new_decl_format */
-  @EnsuresNonNull("FileIO.new_decl_format")
+  @EnsuresNonNull("daikon.FileIO.new_decl_format")
   private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
     ois.defaultReadObject();
     FileIO.new_decl_format = (Boolean) ois.readObject();

--- a/java/daikon/split/PptSplitter.java
+++ b/java/daikon/split/PptSplitter.java
@@ -150,11 +150,11 @@ public class PptSplitter implements Serializable {
   }
 
   /** Adds the sample to one of the conditional ppts in the split. */
-  @SuppressWarnings("flowexpr.parse.error") // private field
   @RequiresNonNull({
-    "NIS.suppressor_map",
-    "NIS.suppressor_map_suppression_count",
-    "NIS.all_suppressions"
+    "daikon.suppress.NIS.suppressor_map",
+    "daikon.suppress.NIS.suppressor_map_suppression_count",
+    "daikon.suppress.NIS.all_suppressions",
+    "daikon.suppress.NIS.suppressor_proto_invs"
   })
   public void add_bottom_up(ValueTuple vt, int count) {
 
@@ -213,8 +213,11 @@ public class PptSplitter implements Serializable {
   }
 
   /** Adds implication invariants based on the invariants found on each side of the split. */
-  @SuppressWarnings("flowexpr.parse.error") // private field
-  @RequiresNonNull({"parent.equality_view", "NIS.all_suppressions", "NIS.suppressor_map"})
+  @RequiresNonNull({
+    "parent.equality_view",
+    "daikon.suppress.NIS.all_suppressions",
+    "daikon.suppress.NIS.suppressor_map"
+  })
   public void add_implications() {
 
     // Currently only binary implications are supported

--- a/java/daikon/tools/InvariantChecker.java
+++ b/java/daikon/tools/InvariantChecker.java
@@ -380,7 +380,7 @@ public class InvariantChecker {
      * process the sample by checking it against each existing invariant and issuing an error if any
      * invariant is falsified or weakened.
      */
-    @RequiresNonNull("FileIO.data_trace_state")
+    @RequiresNonNull("daikon.FileIO.data_trace_state")
     @Override
     public void process_sample(
         PptMap all_ppts, PptTopLevel ppt, ValueTuple vt, @Nullable Integer nonce) {
@@ -430,7 +430,7 @@ public class InvariantChecker {
       add(ppt, vt, all_ppts);
     }
 
-    @RequiresNonNull("FileIO.data_trace_state")
+    @RequiresNonNull("daikon.FileIO.data_trace_state")
     private void add(PptTopLevel ppt, ValueTuple vt, PptMap all_ppts) {
       // Add the sample to any splitters
       if (ppt.has_splitters()) {

--- a/java/daikon/tools/ReadTrace.java
+++ b/java/daikon/tools/ReadTrace.java
@@ -68,7 +68,7 @@ public class ReadTrace {
     public Map<PptTopLevel, List<ValueTuple>> samples = new LinkedHashMap<>();
 
     /** Process the sample, by adding it to the {@code samples} map. */
-    @RequiresNonNull("FileIO.data_trace_state")
+    @RequiresNonNull("daikon.FileIO.data_trace_state")
     @Override
     public void process_sample(
         PptMap all_ppts, PptTopLevel ppt, ValueTuple vt, @Nullable Integer nonce) {


### PR DESCRIPTION
Merge with https://github.com/typetools/checker-framework/pull/4266.
CI fails because of missing Javadoc, so make a non-consequential commit right after merging this pull request.