### PR TITLE
Correct typo in Daikon FAQ

### DIFF
--- a/doc/www/faq.html
+++ b/doc/www/faq.html
@@ -223,7 +223,7 @@ Daikon tend to perform poorly?&rdquo;
 </p>
 
 <p>
-Typically, will run Daikon not on a whole program, but on the particular
+Typically, users will not run Daikon on a whole program, but on the particular
 component(s) of interest.  Trying to run Daikon on too much data will
 overwhelm either Daikon, or else you when you try to examine the output.
 (If you plan to feed the output into another tool, verbosity is less of a


### PR DESCRIPTION
Perhaps this isn't a typo, but I found it difficult to parse the sentence

> Typically, will run Daikon not on a whole program, but on the particular
component(s) of interest.

I am unsure of who or what is running Daikon here, so I defaulted to _users_ in my suggested fix.