### PR TITLE
Fix a possible resource leak in the `Session` constructor

### DIFF
--- a/java/daikon/simplify/Session.java
+++ b/java/daikon/simplify/Session.java
@@ -87,6 +87,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
    * this Session.
    */
   public Session() {
+    PrintStream trace_file = null;
     try {
       List<String> newEnv = new ArrayList<>();
       if (dkconfig_simplify_max_iterations != 0) {
@@ -113,9 +114,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
           trace_count++;
         }
         trace_file = new PrintStream(new FileOutputStream(f));
-      } else {
-        trace_file = null;
       }
+      this.trace_file = trace_file;
 
       // set up command stream
       PrintStream tmp_input = new PrintStream(process.getOutputStream());
@@ -138,7 +138,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
       assert expect.equals(actual) : "Prompt expected, got '" + actual + "'";
 
     } catch (IOException e) {
-      throw new SimplifyError(e.toString());
+      if (trace_file != null) {
+        try {
+          trace_file.close();
+        } catch (Exception closeException) {
+          e.addSuppressed(closeException);
+        }
+      }
+      throw new SimplifyError(e);
     }
   }
 

--- a/java/daikon/simplify/Session.java
+++ b/java/daikon/simplify/Session.java
@@ -87,6 +87,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
    * this Session.
    */
   public Session() {
+    // Note that this local variable shadows `this.trace_file`.
     PrintStream trace_file = null;
     try {
       List<String> newEnv = new ArrayList<>();

--- a/java/daikon/simplify/Session.java
+++ b/java/daikon/simplify/Session.java
@@ -137,7 +137,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
       String actual = new String(buf, 0, pos, UTF_8);
       assert expect.equals(actual) : "Prompt expected, got '" + actual + "'";
 
-    } catch (IOException e) {
+    } catch (Exception | AssertionError e) {
       if (trace_file != null) {
         try {
           trace_file.close();


### PR DESCRIPTION
(Discovered by https://github.com/typetools/checker-framework/pull/6241)

After opening the output stream `trace_file`, the constructor goes on to do many initialization tasks that might throw exceptions.  If that happens, the constructor exits with a `SimplifyError` and does not close `trace_file`, leaking the open output stream.  There is no way for a caller to clean it up because the partially-constructed `Session` is not accessible after the constructor throws.

This commit fixes the problem using a temporary variable with the same name.  On exception the temporary variable will be closed before the constructor exits.

This commit also makes an effort to preserve the entire exception chain on failure, which can be helpful for debugging because it preserves the entire stack trace.