### PR TITLE
Prepend `${HOME}` to Daikon installation location in docs

### DIFF
--- a/doc/daikon.texinfo
+++ b/doc/daikon.texinfo
@@ -264,7 +264,7 @@ We will assume that you are using the bash shell or one of its variants.
 Add commands like these to your @file{~/.bashrc} or @file{~/.bash_profile} file:
 @example
 # The absolute pathname of the directory that contains Daikon
-export DAIKONDIR=@var{daikonparent}/daikon-5.8.19
+export DAIKONDIR=$@{HOME@}/@var{daikonparent}/daikon-5.8.19
 source $DAIKONDIR/scripts/daikon.bashrc
 @end example
 


### PR DESCRIPTION
@mernst I needed to make this change to be able to run Daikon (play-testing for CSE P 504).