### PR TITLE
Use latest Error Prone if java version is 17 or greater.

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -715,10 +715,10 @@ endif
 # and https://errorprone.info/docs/installation .
 ifeq ($(shell test ${JAVA_RELEASE_NUMBER} -lt 17; echo $$?),0)
   error-prone-version = 2.31.0
-  extra-error-prone-args = ""
+  extra-error-prone-args =
 else
   error-prone-version = 2.36.0
-  extra-error-prone-args = "--should-stop=ifError=FLOW"
+  extra-error-prone-args = --should-stop=ifError=FLOW
 endif
 ERRORPRONE_PROCESSOR_PATH := ${DAIKONDIR}/java/lib/error-prone/error_prone_core-${error-prone-version}-with-dependencies.jar:${DAIKONDIR}/java/lib/error-prone/dataflow-errorprone-3.48.4.jar
 

--- a/java/Makefile
+++ b/java/Makefile
@@ -713,7 +713,14 @@ endif
 
 # See version numbers at https://github.com/google/error-prone/releases
 # and https://errorprone.info/docs/installation .
-ERRORPRONE_PROCESSOR_PATH := ${DAIKONDIR}/java/lib/error-prone/error_prone_core-2.31.0-with-dependencies.jar:${DAIKONDIR}/java/lib/error-prone/dataflow-errorprone-3.48.4.jar
+ifeq ($(shell test ${JAVA_RELEASE_NUMBER} -lt 17; echo $$?),0)
+  error-prone-version = 2.31.0
+  extra-error-prone-args = ""
+else
+  error-prone-version = 2.36.0
+  extra-error-prone-args = "--should-stop=ifError=FLOW"
+endif
+ERRORPRONE_PROCESSOR_PATH := ${DAIKONDIR}/java/lib/error-prone/error_prone_core-${error-prone-version}-with-dependencies.jar:${DAIKONDIR}/java/lib/error-prone/dataflow-errorprone-3.48.4.jar
 
 JAVAC_ANNOTATION_PROCESSOR_ARGS ?= \
 	-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
@@ -733,14 +740,16 @@ errorprone: compile errorprone-nocompile
 #   -Xep:PatternMatchingInstanceof:OFF  requires Java 17
 errorprone-nocompile:
 ifeq ($(JAVA8), 1)
-	echo "Error Prone is not run under Java 8"
+	@echo "Error Prone is not run under Java 8"
 else
+	@echo "Using Error Prone version ${error-prone-version}"
 ## MutablePublicArray is off because it suggests a dependency on Google Guava.
 	javac -cp ${DAIKON_CLASSPATH} \
 	  ${JAVAC_ANNOTATION_PROCESSOR_ARGS} \
 	  -XDcompilePolicy=simple -processorpath ${ERRORPRONE_PROCESSOR_PATH} \
 	  '-Xplugin:ErrorProne -Xep:ReferenceEquality:OFF -Xep:StringSplitter:OFF -Xep:AnnotateFormatMethod:OFF -Xep:MutablePublicArray:OFF -Xep:DoNotCallSuggester:OFF -Xep:InlineMeSuggester:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -Xep:ExtendsObject:OFF -Xep:PatternMatchingInstanceof:OFF' \
 	  -Xmaxwarns 100000 -Werror \
+	  ${extra-error-prone-args} \
 	  ${JAVA_FILES_FOR_STYLE}
 endif
 

--- a/java/daikon/Daikon.java
+++ b/java/daikon/Daikon.java
@@ -708,11 +708,11 @@ public final class Daikon {
       System.err.println("Bug in Daikon.  Please report.");
       System.exit(2);
     } else {
-      // This caes should never be executed.
+      // This case should never be executed.
       System.err.println();
-      System.err.println("Bug in Daikon.  Please report.");
+      System.err.println("Unknown problem in Daikon.  Please report.");
       e.printStackTrace(System.err);
-      System.err.println("Bug in Daikon.  Please report.");
+      System.err.println("Unknown problem in Daikon.  Please report.");
       System.exit(2);
     }
   }

--- a/java/daikon/PptName.java
+++ b/java/daikon/PptName.java
@@ -271,7 +271,7 @@ public class PptName implements Serializable {
             result = Integer.parseInt(point.substring(i));
             break;
           } catch (NumberFormatException e) {
-            continue;
+            // continue;
           }
         }
       }

--- a/java/daikon/diff/MatchCountVisitor.java
+++ b/java/daikon/diff/MatchCountVisitor.java
@@ -143,7 +143,7 @@ public class MatchCountVisitor extends PrintAllVisitor {
         // remember identifiers can not begin with [0-9\-]
         if (Character.isDigit(firstChar) || firstChar == '-') {
           if (acceptableNumber(oneToken)) {
-            continue;
+            // continue;
           } else {
             return true;
           }
@@ -152,7 +152,7 @@ public class MatchCountVisitor extends PrintAllVisitor {
       } catch (NumberFormatException e) {
         System.out.println(
             "Should never get here... NumberFormatException in filterOut: " + oneToken);
-        continue;
+        // continue;
       }
     }
     return false;

--- a/java/daikon/inv/binary/twoScalar/Numeric.java.jpp
+++ b/java/daikon/inv/binary/twoScalar/Numeric.java.jpp
@@ -735,8 +735,6 @@ public abstract class CLASSNAME extends SUPERCLASS {
     public String get_format_str(@GuardSatisfied Divides this, OutputFormat format) {
       if (format == OutputFormat.SIMPLIFY) {
         return "(EQ 0 (MOD %var1% %var2%))";
-      // } else if (format == OutputFormat.CSHARPCONTRACT) {
-      //   return "%var1% % %var2% == 0";
       #if defined(TYPEDOUBLE)
       } else if (format.isJavaFamily()) {
         return "daikon.Quant.fuzzy.eq(%var1% % %var2%, 0)";
@@ -934,8 +932,8 @@ public abstract class CLASSNAME extends SUPERCLASS {
     public String get_format_str(@GuardSatisfied Square this, OutputFormat format) {
       if (format == OutputFormat.SIMPLIFY) {
         return "(EQ %var1% (* %var2% %var2))";
-      // } else if (format == OutputFormat.CSHARPCONTRACT) {
-      //   return "%var1% == %var2%*%var2%";
+      } else if (format == OutputFormat.CSHARPCONTRACT) {
+        return "%var1% == %var2%*%var2%";
       } else if (format.isJavaFamily()) {
         #if defined(TYPEDOUBLE)
         return "daikon.Quant.fuzzy.eq(%var1%, %var2%*%var2%)";
@@ -1114,8 +1112,6 @@ public abstract class CLASSNAME extends SUPERCLASS {
     public String get_format_str(@GuardSatisfied BitwiseComplement this, OutputFormat format) {
       if (format == OutputFormat.SIMPLIFY) {
         return "(EQ %var1% (~ %var2%))";
-      // } else if (format == OutputFormat.CSHARPCONTRACT) {
-      //   return "%var1% == ~%var2%";
       #if defined(TYPEDOUBLE)
       } else if (format.isJavaFamily()) {
         return "daikon.Quant.fuzzy.eq(%var1%, ~%var2%)";
@@ -1184,8 +1180,6 @@ public abstract class CLASSNAME extends SUPERCLASS {
         return "(EQ %var1% (|java-bitwise-or| %var2% %var1%))";
       } else if (format == OutputFormat.DAIKON) {
         return "%var2% is a bitwise subset of %var1%";
-      // } else if (format == OutputFormat.CSHARPCONTRACT) {
-      //   return "%var1% == (%var2% | %var1%)";
       #if defined(TYPEDOUBLE)
       } else if (format.isJavaFamily()) {
         return "daikon.Quant.fuzzy.eq(%var1%, %var2% | %var1%)";
@@ -1293,8 +1287,6 @@ public abstract class CLASSNAME extends SUPERCLASS {
     public String get_format_str(@GuardSatisfied BitwiseAndZero this, OutputFormat format) {
       if (format == OutputFormat.SIMPLIFY) {
         return "(EQ (|java-&| %var1% %var2%) 0)";
-      // } else if (format == OutputFormat.CSHARPCONTRACT) {
-      //   return "(%var1% & %var2%) == 0";
       #if defined(TYPEDOUBLE)
       } else if (format.isJavaFamily()) {
         return "daikon.Quant.fuzzy.eq(%var1% & %var2%, 0)";
@@ -1390,8 +1382,6 @@ public abstract class CLASSNAME extends SUPERCLASS {
     public String get_format_str(@GuardSatisfied ShiftZero this, OutputFormat format) {
       if (format == OutputFormat.SIMPLIFY) {
         return "(EQ (|java->>| %var1% %var2%) 0)";
-      // } else if (format == OutputFormat.CSHARPCONTRACT) {
-      //   return "(%var1% >> %var2% == 0)";
       #if defined(TYPEDOUBLE)
       } else if (format.isJavaFamily()) {
         return "daikon.Quant.fuzzy.eq(%var1% >> %var2%, 0)";

--- a/java/daikon/inv/binary/twoScalar/Numeric.java.jpp
+++ b/java/daikon/inv/binary/twoScalar/Numeric.java.jpp
@@ -735,8 +735,8 @@ public abstract class CLASSNAME extends SUPERCLASS {
     public String get_format_str(@GuardSatisfied Divides this, OutputFormat format) {
       if (format == OutputFormat.SIMPLIFY) {
         return "(EQ 0 (MOD %var1% %var2%))";
-      } else if (format == OutputFormat.CSHARPCONTRACT) {
-        return "%var1% % %var2% == 0";
+      // } else if (format == OutputFormat.CSHARPCONTRACT) {
+      //   return "%var1% % %var2% == 0";
       #if defined(TYPEDOUBLE)
       } else if (format.isJavaFamily()) {
         return "daikon.Quant.fuzzy.eq(%var1% % %var2%, 0)";
@@ -934,8 +934,8 @@ public abstract class CLASSNAME extends SUPERCLASS {
     public String get_format_str(@GuardSatisfied Square this, OutputFormat format) {
       if (format == OutputFormat.SIMPLIFY) {
         return "(EQ %var1% (* %var2% %var2))";
-      } else if (format == OutputFormat.CSHARPCONTRACT) {
-        return "%var1% == %var2%*%var2%";
+      // } else if (format == OutputFormat.CSHARPCONTRACT) {
+      //   return "%var1% == %var2%*%var2%";
       } else if (format.isJavaFamily()) {
         #if defined(TYPEDOUBLE)
         return "daikon.Quant.fuzzy.eq(%var1%, %var2%*%var2%)";
@@ -1114,8 +1114,8 @@ public abstract class CLASSNAME extends SUPERCLASS {
     public String get_format_str(@GuardSatisfied BitwiseComplement this, OutputFormat format) {
       if (format == OutputFormat.SIMPLIFY) {
         return "(EQ %var1% (~ %var2%))";
-      } else if (format == OutputFormat.CSHARPCONTRACT) {
-        return "%var1% == ~%var2%";
+      // } else if (format == OutputFormat.CSHARPCONTRACT) {
+      //   return "%var1% == ~%var2%";
       #if defined(TYPEDOUBLE)
       } else if (format.isJavaFamily()) {
         return "daikon.Quant.fuzzy.eq(%var1%, ~%var2%)";
@@ -1184,8 +1184,8 @@ public abstract class CLASSNAME extends SUPERCLASS {
         return "(EQ %var1% (|java-bitwise-or| %var2% %var1%))";
       } else if (format == OutputFormat.DAIKON) {
         return "%var2% is a bitwise subset of %var1%";
-      } else if (format == OutputFormat.CSHARPCONTRACT) {
-        return "%var1% == (%var2% | %var1%)";
+      // } else if (format == OutputFormat.CSHARPCONTRACT) {
+      //   return "%var1% == (%var2% | %var1%)";
       #if defined(TYPEDOUBLE)
       } else if (format.isJavaFamily()) {
         return "daikon.Quant.fuzzy.eq(%var1%, %var2% | %var1%)";
@@ -1293,8 +1293,8 @@ public abstract class CLASSNAME extends SUPERCLASS {
     public String get_format_str(@GuardSatisfied BitwiseAndZero this, OutputFormat format) {
       if (format == OutputFormat.SIMPLIFY) {
         return "(EQ (|java-&| %var1% %var2%) 0)";
-      } else if (format == OutputFormat.CSHARPCONTRACT) {
-        return "(%var1% & %var2%) == 0";
+      // } else if (format == OutputFormat.CSHARPCONTRACT) {
+      //   return "(%var1% & %var2%) == 0";
       #if defined(TYPEDOUBLE)
       } else if (format.isJavaFamily()) {
         return "daikon.Quant.fuzzy.eq(%var1% & %var2%, 0)";
@@ -1390,8 +1390,8 @@ public abstract class CLASSNAME extends SUPERCLASS {
     public String get_format_str(@GuardSatisfied ShiftZero this, OutputFormat format) {
       if (format == OutputFormat.SIMPLIFY) {
         return "(EQ (|java->>| %var1% %var2%) 0)";
-      } else if (format == OutputFormat.CSHARPCONTRACT) {
-        return "(%var1% >> %var2% == 0)";
+      // } else if (format == OutputFormat.CSHARPCONTRACT) {
+      //   return "(%var1% >> %var2% == 0)";
       #if defined(TYPEDOUBLE)
       } else if (format.isJavaFamily()) {
         return "daikon.Quant.fuzzy.eq(%var1% >> %var2%, 0)";

--- a/java/daikon/inv/unary/scalar/Modulus.java
+++ b/java/daikon/inv/unary/scalar/Modulus.java
@@ -317,7 +317,7 @@ public class Modulus extends SingleScalar {
       }
 
       if (m.modulus == 0) {
-        continue;
+        // continue;
       } else if (new_modulus == 0) {
         new_modulus = m.modulus;
       } else {

--- a/java/daikon/test/inv/InvariantAddAndCheckTester.java
+++ b/java/daikon/test/inv/InvariantAddAndCheckTester.java
@@ -338,7 +338,7 @@ public class InvariantAddAndCheckTester {
         String commandLine = getNextRealLine(commands);
         int lineNumber = commands.getLineNumber();
         if (InvariantAddAndCheckTester.isComment(commandLine)) {
-          continue;
+          // continue;
         } else if (isTestTerminator(commandLine)) {
           break;
         } else if (isAddCommand(commandLine) || isCheckCommand(commandLine)) {

--- a/java/daikon/tools/ExtractConsequent.java
+++ b/java/daikon/tools/ExtractConsequent.java
@@ -290,7 +290,7 @@ public class ExtractConsequent {
           for (int i = 0; i < maybe.ppt.var_infos.length; i++) {
             VarInfo vi = maybe.ppt.var_infos[i];
             if (vi.isDerivedParam()) {
-              continue;
+              // continue;
             }
           }
         }

--- a/java/daikon/tools/compare/LogicalCompare.java
+++ b/java/daikon/tools/compare/LogicalCompare.java
@@ -587,7 +587,7 @@ public class LogicalCompare {
       while ((line = reader.readLine()) != null) {
         line = line.trim();
         if (line.equals("") || line.startsWith("#")) {
-          continue;
+          // continue;
         } else if (line.startsWith("PPT_NAME")) {
           ppt_name = line.substring("PPT_NAME".length()).trim();
           if (!extra_assumptions.containsKey(ppt_name)) {

--- a/java/daikon/tools/jtb/AnnotateVisitor.java
+++ b/java/daikon/tools/jtb/AnnotateVisitor.java
@@ -679,7 +679,7 @@ public class AnnotateVisitor extends DepthFirstVisitor {
         if (insert_inexpressible) {
           addComment(n, javaLineComment("! " + inv + ";"), true);
         }
-        continue;
+        // continue;
       } else {
         String commentContents =
             (Daikon.output_format == OutputFormat.DBCJAVA ? "  " : "@ ")

--- a/java/daikon/tools/jtb/PptNameMatcher.java
+++ b/java/daikon/tools/jtb/PptNameMatcher.java
@@ -266,7 +266,7 @@ public class PptNameMatcher {
       if (!typeMatch(pptTypeString, astType)) {
         return false;
       } else {
-        continue;
+        // continue;
       }
     }
 


### PR DESCRIPTION
Source corrections for a new warning: unneeded 'continue
and a new error:  if branches contain identical code.

I commented out the continues rather than deleting them; feel free to delete if you wish.

The identical code branches were in a .jpp file where there was a '#if' within an if statement.   Also tried to just comment out, but wasn't sure if:
return "%var1% == %var2%*%var2%";
was the same as:
return "%var1% == %var2%**2";