### PR TITLE
remove unused statement that causes warning with newer python3

### DIFF
--- a/scripts/decls2comp.py
+++ b/scripts/decls2comp.py
@@ -102,8 +102,6 @@ COMP_START = "comparability "
 # following format: '9[10]' - we are going to ignore what is between
 # the brackets so we will treat it as '9'
 
-LWArrayRExp = re.compile("\[.\]")
-
 ignoreHashcodes = False
 
 if len(sys.argv) < 2:


### PR DESCRIPTION
LWArrayRExp doesn't appear to be used  and the re.compile expression gets a warning with newer versions of Python3.  Might be the case that the comment just prior to the deleted statement is no longer needed.