### PR TITLE
Misc fixes

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -140,10 +140,6 @@ ifneq "$(wildcard ${SORT_DIRECTORY_ORDER})" "${SORT_DIRECTORY_ORDER}"
   SORT_DIRECTORY_ORDER = sort
 endif
 
-# Currently, there are four files that require Java 24:
-# chicory/Instrument24.java chicory/MethodGen24.java
-# dcomp/Instrument24.java dcomp/DCinstrument24.java.
-
 DAIKON_JAVA_FILES := $(shell find daikon/ -name '*.java' -not -name '*\#*' -print | ${SORT_DIRECTORY_ORDER})
 ifeq ($(JAVA24), 0)
   DAIKON_JAVA_FILES :=  $(filter-out %24.java, $(DAIKON_JAVA_FILES))

--- a/java/daikon/chicory/DaikonWriter.java
+++ b/java/daikon/chicory/DaikonWriter.java
@@ -116,7 +116,7 @@ public abstract class DaikonWriter {
       // replace <init>'s with the actual class name
       // so "public void <init>" becomes "public void StackAr" for example
       short_name = fullClassName.substring(fullClassName.lastIndexOf('.') + 1);
-      // name = name.replace("<init>", short_name);
+      name = name.replace("<init>", short_name);
     }
 
     // build up the string to go inside the parens

--- a/java/daikon/chicory/DaikonWriter.java
+++ b/java/daikon/chicory/DaikonWriter.java
@@ -105,16 +105,18 @@ public abstract class DaikonWriter {
   private static String methodName(
       String fullClassName, String[] types, String name, String short_name, String point) {
 
+    // UNDONE: name is no longer used
+
     // System.out.printf("fullclass: %s !!! name: %s !!! short_name: %s %n",
     //                  fullClassName, name, short_name);
 
-    boolean isConstructor = name.equals("<init>") || name.equals("");
+    boolean isConstructor = short_name.equals("<init>") || short_name.equals("");
 
     if (isConstructor) {
       // replace <init>'s with the actual class name
       // so "public void <init>" becomes "public void StackAr" for example
       short_name = fullClassName.substring(fullClassName.lastIndexOf('.') + 1);
-      name = name.replace("<init>", short_name);
+      // name = name.replace("<init>", short_name);
     }
 
     // build up the string to go inside the parens

--- a/java/daikon/dcomp/DCInstrument.java
+++ b/java/daikon/dcomp/DCInstrument.java
@@ -3096,9 +3096,9 @@ public class DCInstrument extends InstructionListUtils {
     String full_name = m.toString();
     full_name = full_name.replaceFirst("\\s*throws.*", "");
 
-    return fullClassName
-        + "."
-        + DaikonWriter.methodEntryName(fullClassName, type_names, full_name, m.getName());
+    // UNDONE: full_name is not used by DaikonWriter.methodEntryName.
+
+    return DaikonWriter.methodEntryName(fullClassName, type_names, full_name, m.getName());
   }
 
   /**

--- a/java/daikon/dcomp/Premain.java
+++ b/java/daikon/dcomp/Premain.java
@@ -51,7 +51,8 @@ public class Premain {
 
   /**
    * Specifies if we are to use an instrumented version of the JDK. Calls into the JDK must be
-   * modified to remove the arguments from the tag stack if the JDK is not instrumented.
+   * modified to remove the arguments from the tag stack if the JDK is not instrumented. The default
+   * value is set to true for BuildJDK. Other tools will set this flag based on their options.
    */
   protected static boolean jdk_instrumented = true; // default to true for BuildJDK
 


### PR DESCRIPTION
Issues with master branch noted while working on java-24-dcomp-2.

DCInstrument.methodEntryName was generating `<full classname>.<full classname><rest of ppt stuff>`.

DaikonWriter.methodName was using `<full classname>` to check for `<init>`.
