### PR TITLE
fix for Daikon issue 618

### DIFF
--- a/java/daikon/chicory/Instrument.java
+++ b/java/daikon/chicory/Instrument.java
@@ -238,6 +238,11 @@ public class Instrument extends InstructionListUtils implements ClassFileTransfo
       return null;
     }
 
+    if (className.contains("/$Proxy")) {
+      debug_transform.log("Skipping proxy class %s%n", binaryClassName);
+      return null;
+    }
+
     // Don't instrument our own code.
     if (isChicory(className)) {
       debug_transform.log("Not transforming Chicory class %s%n", binaryClassName);


### PR DESCRIPTION
Chicory needs to ignore JDK proxy classes. DynComp already does this. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds a safeguard to automatically skip instrumentation of Java dynamic proxy classes, improving compatibility with applications that use proxies.
- Bug Fixes
  - Prevents potential errors and unexpected behavior caused by attempting to instrument proxy-generated classes.
- Documentation
  - Debug logs now clearly indicate when proxy classes are skipped during processing.
- Chores
  - No changes to public APIs; behavior is adjusted internally to ignore proxy classes without affecting existing integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->