### PR TITLE
Rename `getLocalVariables()` to `getOriginalLocalVariables()`

### DIFF
--- a/java/daikon/chicory/Instrument24.java
+++ b/java/daikon/chicory/Instrument24.java
@@ -538,7 +538,7 @@ public class Instrument24 implements ClassFileTransformer {
           if (debugInstrument.enabled) {
             ClassDesc[] paramTypes = mgen.getParameterTypes();
             String[] paramNames = mgen.getParameterNames();
-            LocalVariable[] local_vars = mgen.getLocalVariables();
+            LocalVariable[] local_vars = mgen.getOriginalLocalVariables();
             String types = "", names = "", locals = "";
 
             for (int j = 0; j < paramTypes.length; j++) {
@@ -1356,7 +1356,7 @@ public class Instrument24 implements ClassFileTransformer {
 
     // Get the parameter names for this method.
     String[] paramNames = mgen.getParameterNames();
-    LocalVariable[] lvs = mgen.getLocalVariables();
+    LocalVariable[] lvs = mgen.getOriginalLocalVariables();
     int param_offset = 1;
     if (mgen.isStatic()) {
       param_offset = 0;

--- a/java/daikon/chicory/MethodGen24.java
+++ b/java/daikon/chicory/MethodGen24.java
@@ -360,11 +360,12 @@ public class MethodGen24 {
   }
 
   /**
-   * Returns the local variable table.
+   * Returns the original local variable table. In most cases, instrumentation code should use the
+   * {@code localsTable} instead.
    *
-   * @return the local variable table
+   * @return the original local variable table
    */
-  public LocalVariable[] getLocalVariables() {
+  public LocalVariable[] getOriginalLocalVariables() {
     return origLocalVariables.clone();
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Debug logging now displays original local variable names consistently.
- Refactor
  - Renamed a public API to clarify access to original local variable information; may require minor updates for integrations relying on the old name.
- Documentation
  - Updated API comments to clearly distinguish original local variable data from instrumentation-specific data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->