### PR TITLE
Use access flags via mask

### DIFF
--- a/java/daikon/chicory/Instrument24.java
+++ b/java/daikon/chicory/Instrument24.java
@@ -59,7 +59,6 @@ import java.lang.constant.MethodTypeDesc;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.lang.invoke.MethodHandles;
-import java.lang.reflect.AccessFlag;
 import java.nio.file.Files;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
@@ -520,7 +519,7 @@ public class Instrument24 implements ClassFileTransformer {
           }
 
           // If method is synthetic... (default constructors and <clinit> are not synthetic).
-          if (mgen.getAccessFlags().has(AccessFlag.SYNTHETIC)) {
+          if ((mgen.getAccessFlagsMask() & ClassFile.ACC_SYNTHETIC) != 0) {
             // We are not going to instrument this method.
             // We need to copy it to the output class.
             outputMethodUnchanged(classBuilder, mm, mgen);

--- a/java/daikon/chicory/MethodGen24.java
+++ b/java/daikon/chicory/MethodGen24.java
@@ -1,8 +1,8 @@
 package daikon.chicory;
 
-import java.lang.classfile.AccessFlags;
 import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassBuilder;
+import java.lang.classfile.ClassFile;
 import java.lang.classfile.CodeBuilder;
 import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeModel;
@@ -15,7 +15,6 @@ import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.instruction.LocalVariable;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
-import java.lang.reflect.AccessFlag;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -54,8 +53,8 @@ public class MethodGen24 {
    */
   private @Nullable CodeModel code;
 
-  /** The method's access flags. */
-  private AccessFlags accessFlags;
+  /** The method's access flags as a bit mask. */
+  private int accessFlagsMask;
 
   /** The method's name. */
   private String methodName;
@@ -200,13 +199,13 @@ public class MethodGen24 {
       final @BinaryName String className,
       ClassBuilder classBuilder) {
 
-    accessFlags = methodModel.flags();
+    accessFlagsMask = methodModel.flags().flagsMask();
     methodName = methodModel.methodName().stringValue();
     @SuppressWarnings("signature") // JDK 24 is not annotated as yet
     @MethodDescriptor String descriptor1 = methodModel.methodType().stringValue();
     descriptor = descriptor1;
     this.className = className;
-    isStatic = accessFlags.has(AccessFlag.STATIC);
+    isStatic = (accessFlagsMask & ClassFile.ACC_STATIC) != 0;
 
     Optional<CodeModel> code = methodModel.code();
     if (code.isPresent()) {
@@ -290,8 +289,8 @@ public class MethodGen24 {
    *
    * @return the access flags
    */
-  public AccessFlags getAccessFlags() {
-    return accessFlags;
+  public int getAccessFlagsMask() {
+    return accessFlagsMask;
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal method-flag handling to use a more direct bitmask approach for improved consistency and maintainability.
  * Synthetic methods continue to be detected and excluded from instrumentation as before; no functional changes expected.

* **Documentation**
  * Clarified internal comments related to access flag handling.

No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->