### PR TITLE
Support `SKIP_TEST`

### DIFF
--- a/tests/Makefile.common
+++ b/tests/Makefile.common
@@ -869,12 +869,24 @@ txt-all: ${PROJECT_FILE}.txt-daikon ${PROJECT_FILE}.txt-simplify merge;
 endif
 endif
 
+ifdef SKIP_TEST
+diffs:
+	@echo "SKIP_TEST is set for: ${PROJECT_FILE}"
+else
 PROJECT_HELP:=${PROJECT_HELP} ;\
   echo "  make diffs          : run all regression tests and display results"
 diffs: txt-diff results
+endif
 
 PROJECT_HELP:=${PROJECT_HELP} ;\
   echo "  make txt-diff       : makes .diff files (from diff -u $$.goal)"
+
+ifdef SKIP_TEST
+txt-diff:
+	@echo "SKIP_TEST is set for: ${PROJECT_FILE}"
+else
+
+# !SKIP_TEST
 
 ifdef ESC_ON
 ifndef NO_MERGE
@@ -948,6 +960,7 @@ endif
 endif # ifndef NO_MERGE
 endif # ifdef NO_JML
 endif # ifdef ESC_ON
+endif # ifdef SKIP_TEST
 
 txt-daikon-diff: ${PROJECT_FILE}.txt-daikon.diff;
 txt-daikon-end2end-diff: ${PROJECT_FILE}.txt-daikon-end2end.diff;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a SKIP_TEST flag to optionally bypass test execution and diff generation.
  * Introduced a diffs target that, when SKIP_TEST is set, prints a skip notice; otherwise it behaves normally and aggregates diff and result checks.
  * Updated txt-diff to respect SKIP_TEST, printing a skip notice when enabled while preserving the existing diff logic when not.
  * No changes to underlying comparison logic; this update improves control over when tests and diffs run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->