### PR TITLE
Use small resource class for canary job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ jobs:
   # Only proceed to other jobs if canary-jobs passes.
   canary-jobs:
     docker:
-      - image: cimg/base:2022.06
+      - image: 'cimg/base:2025.09'
+    resource_class: small
     environment:
       CIRCLE_COMPARE_URL: << pipeline.project.git_url >>/compare/<< pipeline.git.base_revision >>..<<pipeline.git.revision>>
       TERM: dumb

--- a/.circleci/config.yml.m4
+++ b/.circleci/config.yml.m4
@@ -9,7 +9,8 @@ jobs:
   # Only proceed to other jobs if canary-jobs passes.
   canary-jobs:
     docker:
-      - image: cimg/base:2022.06
+      - image: 'cimg/base:2025.09'
+    resource_class: small
     environment:
       CIRCLE_COMPARE_URL: << pipeline.project.git_url >>/compare/<< pipeline.git.base_revision >>..<<pipeline.git.revision>>
       TERM: dumb


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI canary jobs to use a newer base image for improved compatibility and security.
  * Adjusted CI resource allocation for canary jobs to a smaller class to optimize build resource usage.
  * No changes to app features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->