### PR TITLE
Use Error Prone version 2.42.0

### DIFF
--- a/SKIP-REQUIRE-JAVADOC
+++ b/SKIP-REQUIRE-JAVADOC
@@ -1,0 +1,1 @@
+Remove this file after the pull request is merged.

--- a/java/Makefile
+++ b/java/Makefile
@@ -804,11 +804,11 @@ ifeq ($(shell test ${JAVA_RELEASE_NUMBER} -lt 17; echo $$?),0)
   error-prone-version = 2.31.0
   extra-error-prone-args-1 =
 else
-  error-prone-version = 2.36.0
+  error-prone-version = 2.42.0
   extra-error-prone-args-1 = --should-stop=ifError=FLOW
 endif
 
-ERRORPRONE_PROCESSOR_PATH := ${DAIKONDIR}/java/lib/error-prone/error_prone_core-${error-prone-version}-with-dependencies.jar:${DAIKONDIR}/java/lib/error-prone/dataflow-errorprone-3.48.4.jar
+ERRORPRONE_PROCESSOR_PATH := ${DAIKONDIR}/java/lib/error-prone/error_prone_core-${error-prone-version}-with-dependencies.jar:${DAIKONDIR}/java/lib/error-prone/dataflow-errorprone-3.51.0.jar
 
 JAVAC_ANNOTATION_PROCESSOR_ARGS ?= \
 	-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \

--- a/java/Makefile
+++ b/java/Makefile
@@ -808,7 +808,7 @@ else
   extra-error-prone-args-1 = --should-stop=ifError=FLOW
 endif
 
-ERRORPRONE_PROCESSOR_PATH := ${DAIKONDIR}/java/lib/error-prone/error_prone_core-${error-prone-version}-with-dependencies.jar:${DAIKONDIR}/java/lib/error-prone/dataflow-errorprone-3.51.0.jar
+ERRORPRONE_PROCESSOR_PATH := ${DAIKONDIR}/java/lib/error-prone/error_prone_core-${error-prone-version}-with-dependencies.jar:${DAIKONDIR}/java/lib/error-prone/dataflow-errorprone-3.49.3-eisop1.jar
 
 JAVAC_ANNOTATION_PROCESSOR_ARGS ?= \
 	-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
@@ -835,7 +835,7 @@ else
 	javac -cp ${DAIKON_CLASSPATH} \
 	  ${JAVAC_ANNOTATION_PROCESSOR_ARGS} \
 	  -XDcompilePolicy=simple -processorpath ${ERRORPRONE_PROCESSOR_PATH} \
-	  '-Xplugin:ErrorProne -Xep:ReferenceEquality:OFF -Xep:StringSplitter:OFF -Xep:AnnotateFormatMethod:OFF -Xep:MutablePublicArray:OFF -Xep:DoNotCallSuggester:OFF -Xep:InlineMeSuggester:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -Xep:ExtendsObject:OFF -Xep:PatternMatchingInstanceof:OFF' \
+	  '-Xplugin:ErrorProne -Xep:ReferenceEquality:OFF -Xep:StringSplitter:OFF -Xep:AnnotateFormatMethod:OFF -Xep:MutablePublicArray:OFF -Xep:DoNotCallSuggester:OFF -Xep:InlineMeSuggester:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -Xep:ExtendsObject:OFF -Xep:PatternMatchingInstanceof:OFF -Xep:StatementSwitchToExpressionSwitch:OFF' \
 	  -Xmaxwarns 100000 \
 	  -Werror \
 	  ${extra-error-prone-args-1} \

--- a/java/daikon/Daikon.java
+++ b/java/daikon/Daikon.java
@@ -2498,7 +2498,7 @@ public final class Daikon {
   }
 
   private static class Count {
-    public int val;
+    int val;
 
     Count(int val) {
       this.val = val;

--- a/java/daikon/DynamicConstants.java
+++ b/java/daikon/DynamicConstants.java
@@ -137,7 +137,7 @@ public class DynamicConstants implements Serializable {
     public int count = 0;
 
     /** The variable that has this value. */
-    public VarInfo vi;
+    public final VarInfo vi;
 
     /** True if this has been missing for every sample to date. */
     boolean always_missing = true;

--- a/java/daikon/PptName.java
+++ b/java/daikon/PptName.java
@@ -499,7 +499,7 @@ public class PptName implements Serializable {
 
   // ==================== OBJECT METHODS ====================
 
-  /* @return interned string such that this.equals(new PptName(this.toString())) */
+  // Returns an interned string such that `this.equals(new PptName(this.toString()))`.
   @SideEffectFree
   @Override
   public String toString(@GuardSatisfied PptName this) {

--- a/java/daikon/PptRelation.java
+++ b/java/daikon/PptRelation.java
@@ -628,10 +628,10 @@ public class PptRelation implements Serializable {
 
   // used by init_hierarchy below
   private static class SplitChild {
-    public PptRelation rel;
-    public PptSplitter ppt_split;
+    PptRelation rel;
+    PptSplitter ppt_split;
 
-    public SplitChild(PptRelation rel, PptSplitter ppt_split) {
+    SplitChild(PptRelation rel, PptSplitter ppt_split) {
       this.rel = rel;
       this.ppt_split = ppt_split;
     }

--- a/java/daikon/PptSlice0.java
+++ b/java/daikon/PptSlice0.java
@@ -159,11 +159,11 @@ public class PptSlice0 extends PptSlice {
 
   private static final class ImplicationWrapper {
 
-    public Implication theImp;
+    Implication theImp;
     // hashCode is cached to make equality checks faster.
     private int hashCode;
 
-    public ImplicationWrapper(Implication theImp) {
+    ImplicationWrapper(Implication theImp) {
       this.theImp = theImp;
       // this.format = theImp.format();
       this.hashCode = 0;

--- a/java/daikon/PptSlice0.java
+++ b/java/daikon/PptSlice0.java
@@ -159,7 +159,7 @@ public class PptSlice0 extends PptSlice {
 
   private static final class ImplicationWrapper {
 
-    Implication theImp;
+    final Implication theImp;
     // hashCode is cached to make equality checks faster.
     private int hashCode;
 

--- a/java/daikon/PptSliceEquality.java
+++ b/java/daikon/PptSliceEquality.java
@@ -91,7 +91,7 @@ public class PptSliceEquality extends PptSlice {
    * VarComparability.comparable() to each other.
    */
   private static class VarInfoAndComparability {
-    VarInfo vi;
+    final VarInfo vi;
 
     @Pure
     @Override

--- a/java/daikon/PptSliceEquality.java
+++ b/java/daikon/PptSliceEquality.java
@@ -91,7 +91,7 @@ public class PptSliceEquality extends PptSlice {
    * VarComparability.comparable() to each other.
    */
   private static class VarInfoAndComparability {
-    public VarInfo vi;
+    VarInfo vi;
 
     @Pure
     @Override
@@ -120,7 +120,7 @@ public class PptSliceEquality extends PptSlice {
      */
     @EnsuresNonNullIf(result = true, expression = "#1")
     @Pure
-    public boolean equalsVarInfoAndComparability(
+    boolean equalsVarInfoAndComparability(
         @GuardSatisfied VarInfoAndComparability this, @GuardSatisfied VarInfoAndComparability o) {
 
       return (vi.comparableNWay(o.vi)
@@ -128,7 +128,7 @@ public class PptSliceEquality extends PptSlice {
           && vi.aux.equals_for_instantiation(o.vi.aux));
     }
 
-    public VarInfoAndComparability(VarInfo vi) {
+    VarInfoAndComparability(VarInfo vi) {
       this.vi = vi;
     }
   }

--- a/java/daikon/PptTopLevel.java
+++ b/java/daikon/PptTopLevel.java
@@ -4050,6 +4050,7 @@ public class PptTopLevel extends Ppt {
    * sets at the parent, the invariants true at A in the child are the union of those true at A and
    * B at the parent.
    */
+  @SuppressWarnings("AssignmentExpression") // for "assert (assert_enabled = true);"
   public VarInfo @Nullable [] parent_vis(PptRelation rel, PptSlice slice) {
 
     /*NNC:@MonotonicNonNull*/ VarInfo[] pvis = new VarInfo[slice.var_infos.length];

--- a/java/daikon/VarInfo.java
+++ b/java/daikon/VarInfo.java
@@ -4262,15 +4262,14 @@ public final @Interned class VarInfo implements Cloneable, Serializable {
     return vi;
   }
 
-  /*
+  /**
    * Creates the derived variable func(seq) from seq.
    *
    * @param func_name name of the function
-   * @param type return type of the function.  If null, the return type is
-   *             the element type of the sequence.
+   * @param type return type of the function. If null, the return type is the element type of the
+   *     sequence.
    * @param seq sequence variable
-   * @param shift value to add or subtract from the function.  Legal values
-   *              are -1, 0, and 1.
+   * @param shift value to add or subtract from the function. Legal values are -1, 0, and 1.
    */
   public static VarInfo make_scalar_seq_func(
       String func_name, @Nullable ProglangType type, VarInfo seq, int shift) {
@@ -4357,7 +4356,7 @@ public final @Interned class VarInfo implements Cloneable, Serializable {
     return vi;
   }
 
-  /*
+  /**
    * Creates the derived variable func(str) from string.
    *
    * @param func_name name of the function

--- a/java/daikon/chicory/DeclWriter.java
+++ b/java/daikon/chicory/DeclWriter.java
@@ -391,6 +391,7 @@ public class DeclWriter extends DaikonWriter implements ComparabilityProvider {
      * parent-ppt-name id parent-variable-name. If the variable is static, it always has the same
      * name in the parent (since fully specified names are used for static variables).
      */
+    @SideEffectFree
     String relation_str(DaikonVariableInfo var) {
       String out = parent_ppt_name + " " + id;
       if (!var.isStatic() && (local_prefix != null) && !local_prefix.equals(parent_prefix)) {

--- a/java/daikon/chicory/DeclWriter.java
+++ b/java/daikon/chicory/DeclWriter.java
@@ -350,7 +350,7 @@ public class DeclWriter extends DaikonWriter implements ComparabilityProvider {
     static SimpleLog debug = new SimpleLog(false);
 
     /** Create a VarRelation. */
-    public VarRelation(
+    VarRelation(
         String parent_ppt_name,
         String type,
         String local_prefix,
@@ -365,7 +365,7 @@ public class DeclWriter extends DaikonWriter implements ComparabilityProvider {
     }
 
     /** Create a var relation with the matching names. */
-    public VarRelation(String parent_ppt_name, String type) {
+    VarRelation(String parent_ppt_name, String type) {
       this(parent_ppt_name, type, null, null, null);
     }
 
@@ -382,7 +382,7 @@ public class DeclWriter extends DaikonWriter implements ComparabilityProvider {
      * variable at the class level.
      */
     @Pure
-    public boolean is_class_relation() {
+    boolean is_class_relation() {
       return parent_ppt_name.endsWith(":::CLASS");
     }
 
@@ -391,7 +391,7 @@ public class DeclWriter extends DaikonWriter implements ComparabilityProvider {
      * parent-ppt-name id parent-variable-name. If the variable is static, it always has the same
      * name in the parent (since fully specified names are used for static variables).
      */
-    public String relation_str(DaikonVariableInfo var) {
+    String relation_str(DaikonVariableInfo var) {
       String out = parent_ppt_name + " " + id;
       if (!var.isStatic() && (local_prefix != null) && !local_prefix.equals(parent_prefix)) {
         out += " " + var.getName().replaceFirst(Pattern.quote(local_prefix), parent_prefix);

--- a/java/daikon/chicory/Instrument.java
+++ b/java/daikon/chicory/Instrument.java
@@ -189,7 +189,7 @@ public class Instrument extends InstructionListUtils implements ClassFileTransfo
     return false;
   }
 
-  /*
+  /**
    * Output a .class file and a .bcel version of the class file.
    *
    * @param c the Java class to output

--- a/java/daikon/chicory/Instrument24.java
+++ b/java/daikon/chicory/Instrument24.java
@@ -226,7 +226,7 @@ public class Instrument24 implements ClassFileTransformer {
     return false;
   }
 
-  /*
+  /**
    * Output a .class file and a .bcel version of the class file.
    *
    * @param classBytes a byte array of the class file to output
@@ -1142,10 +1142,10 @@ public class Instrument24 implements ClassFileTransformer {
   private static class ModifiedSwitchInfo {
 
     /** Possibly modified default switch target. */
-    public Label modifiedTarget;
+    Label modifiedTarget;
 
     /** Possibly modified switch case list. */
-    public List<SwitchCase> modifiedCaseList;
+    List<SwitchCase> modifiedCaseList;
 
     /**
      * Creates a ModifiedSwitchInfo.
@@ -1153,7 +1153,7 @@ public class Instrument24 implements ClassFileTransformer {
      * @param modifiedTarget possibly modified default switch target
      * @param modifiedCaseList possibly modified switch case list
      */
-    public ModifiedSwitchInfo(Label modifiedTarget, List<SwitchCase> modifiedCaseList) {
+    ModifiedSwitchInfo(Label modifiedTarget, List<SwitchCase> modifiedCaseList) {
       this.modifiedTarget = modifiedTarget;
       this.modifiedCaseList = modifiedCaseList;
     }

--- a/java/daikon/chicory/Runtime.java
+++ b/java/daikon/chicory/Runtime.java
@@ -142,7 +142,7 @@ public class Runtime {
     boolean captured;
 
     @Holding("Runtime.class")
-    public CallInfo(int nonce, boolean captured) {
+    CallInfo(int nonce, boolean captured) {
       this.nonce = nonce;
       this.captured = captured;
     }

--- a/java/daikon/chicory/ThisObjInfo.java
+++ b/java/daikon/chicory/ThisObjInfo.java
@@ -28,9 +28,7 @@ public class ThisObjInfo extends DaikonVariableInfo {
     this.type = type;
   }
 
-  /* (non-Javadoc)
-   * @see daikon.chicory.DaikonVariableInfo#getChildValue(java.lang.Object)
-   */
+  // See daikon.chicory.DaikonVariableInfo#getChildValue(java.lang.Object)
   @Override
   public @Nullable Object getMyValFromParentVal(Object val) {
     throw new Error("shouldn't be called");

--- a/java/daikon/config/Configuration.java
+++ b/java/daikon/config/Configuration.java
@@ -232,9 +232,9 @@ public final class Configuration implements Serializable {
 
     if (type.equals(Boolean.TYPE)) {
       if (unparsed.equals("1") || unparsed.equalsIgnoreCase("true")) {
-        value = Boolean.TRUE;
+        value = true;
       } else if (unparsed.equals("0") || unparsed.equalsIgnoreCase("false")) {
-        value = Boolean.FALSE;
+        value = false;
       } else {
         throw new ConfigException(
             "Badly formatted boolean argument "

--- a/java/daikon/dcomp/DCRuntime.java
+++ b/java/daikon/dcomp/DCRuntime.java
@@ -180,8 +180,8 @@ public final class DCRuntime implements ComparabilityProvider {
    */
   @SuppressWarnings("UnusedVariable") // used only for debugging
   private static class UninitFieldTag {
-    String descr;
-    Throwable stack_trace;
+    final String descr;
+    final Throwable stack_trace;
 
     UninitFieldTag(String descr, Throwable stack_trace) {
       this.descr = descr;

--- a/java/daikon/dcomp/DCRuntime.java
+++ b/java/daikon/dcomp/DCRuntime.java
@@ -183,7 +183,7 @@ public final class DCRuntime implements ComparabilityProvider {
     String descr;
     Throwable stack_trace;
 
-    public UninitFieldTag(String descr, Throwable stack_trace) {
+    UninitFieldTag(String descr, Throwable stack_trace) {
       this.descr = descr;
       this.stack_trace = stack_trace;
     }
@@ -374,7 +374,7 @@ public final class DCRuntime implements ComparabilityProvider {
         return_val = ((Boolean) m.invoke(o1, o2, null));
       } else {
         // Push tag for return value, and call the uninstrumented version
-        @MustCall() ThreadData td = thread_to_data.get(Thread.currentThread());
+        @MustCall ThreadData td = thread_to_data.get(Thread.currentThread());
         td.tag_stack.push(new Constant());
         Method m = o1super.getMethod("equals", new Class<?>[] {java_lang_Object_class});
         return_val = ((Boolean) m.invoke(o1, o2));
@@ -2239,7 +2239,7 @@ public final class DCRuntime implements ComparabilityProvider {
       }
     }
 
-    public void sort() {
+    void sort() {
       Collections.sort(this);
     }
   }

--- a/java/daikon/dcomp/Instrument.java
+++ b/java/daikon/dcomp/Instrument.java
@@ -72,7 +72,7 @@ public class Instrument implements ClassFileTransformer {
     System.out.println();
   }
 
-  /*
+  /**
    * Output a .class file and a .bcel version of the class file.
    *
    * @param c the Java class to output

--- a/java/daikon/inv/Invariant.java
+++ b/java/daikon/inv/Invariant.java
@@ -671,6 +671,7 @@ public abstract class Invariant implements Serializable, Cloneable // but don't 
    * @param parent_ppt slice that will contain the new invariant
    * @return the merged invariant or null if the invariants didn't represent the same invariant
    */
+  @SuppressWarnings("AssignmentExpression") // for "assert (assert_enabled = true);"
   public @Nullable @NonPrototype Invariant merge(
       @Prototype Invariant this, List<@NonPrototype Invariant> invs, PptSlice parent_ppt) {
 

--- a/java/daikon/simplify/Session.java
+++ b/java/daikon/simplify/Session.java
@@ -86,6 +86,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
    * Initializes the simplify environment for interaction. Use {@code Cmd} objects to interact with
    * this Session.
    */
+  @SuppressWarnings("AssignmentExpression") // for "while ((f = new File ..."
   public Session() {
     // Note that this local variable shadows `this.trace_file`.
     PrintStream trace_file = null;

--- a/java/daikon/simplify/SimpUtil.java
+++ b/java/daikon/simplify/SimpUtil.java
@@ -6,6 +6,12 @@ public class SimpUtil {
     throw new Error("do not instantiate");
   }
 
+  /**
+   * Throws an exception if the string is not a Simplify expression.
+   *
+   * @param s a Simplify expression
+   */
+  @SuppressWarnings("AssignmentExpression") // for "assert (assert_enabled = true);"
   public static void assert_well_formed(String s) {
     boolean assert_enabled = false;
     assert (assert_enabled = true);

--- a/java/daikon/suppress/NISuppressor.java
+++ b/java/daikon/suppress/NISuppressor.java
@@ -220,7 +220,8 @@ public class NISuppressor {
 
     // If the underlying invariant is not enabled, we can't possibly be true
     if (!is_enabled()) {
-      return (state = NIS.SuppressState.INVALID);
+      state = NIS.SuppressState.INVALID;
+      return state;
     }
 
     if (Debug.logDetail() && NIS.debug.isLoggable(Level.FINE)) {
@@ -245,7 +246,8 @@ public class NISuppressor {
       if (!instantiate_ok(new VarInfo[] {v1})) {
         // System.out.printf("suppressor %s invalid over variable %s%n",
         //                   this, v1);
-        return (state = NIS.SuppressState.INVALID);
+        state = NIS.SuppressState.INVALID;
+        return state;
       }
 
       // Check to see if inv matches this suppressor.  The invariant class
@@ -253,7 +255,8 @@ public class NISuppressor {
       // needed for the falsified method.
       if (!NIS.antecedent_method) {
         if ((inv != null) && (inv.getClass() == inv_class) && (v1 == inv.ppt.var_infos[0])) {
-          return (state = NIS.SuppressState.MATCH);
+          state = NIS.SuppressState.MATCH;
+          return state;
         }
       }
 
@@ -277,13 +280,15 @@ public class NISuppressor {
         } else {
           current_state_str = "invalid over constant " + ppt.constants.constant_value(v1);
         }
-        return (state = (valid ? NIS.SuppressState.VALID : NIS.SuppressState.INVALID));
+        state = (valid ? NIS.SuppressState.VALID : NIS.SuppressState.INVALID);
+        return state;
       }
 
       // Check to see the variable is missing
       if (ppt.is_prev_missing(v1)) {
         current_state_str = "nonsensical";
-        return (state = NIS.SuppressState.NONSENSICAL);
+        state = NIS.SuppressState.NONSENSICAL;
+        return state;
       }
 
       // Check to see if this suppressor is true.  Note that we don't check
@@ -296,12 +301,14 @@ public class NISuppressor {
         for (Invariant slice_inv : slice.invs) {
           if (match_true(slice_inv)) {
             current_state_str = "invariant " + slice_inv.format();
-            return (state = NIS.SuppressState.VALID);
+            state = NIS.SuppressState.VALID;
+            return state;
           }
         }
       }
       current_state_str = "invariant not found";
-      return (state = NIS.SuppressState.INVALID);
+      state = NIS.SuppressState.INVALID;
+      return state;
 
     } else /* must be binary */ {
       if (v1_index >= vis.length || v2_index >= vis.length) {
@@ -320,7 +327,8 @@ public class NISuppressor {
       if (!instantiate_ok(new VarInfo[] {v1, v2})) {
         // System.out.printf("suppressor %s invalid over variables %s & %s%n",
         //                  this, v1, v2);
-        return (state = NIS.SuppressState.INVALID);
+        state = NIS.SuppressState.INVALID;
+        return state;
       }
 
       // Check to see if inv matches this suppressor.  The invariant class,
@@ -334,7 +342,8 @@ public class NISuppressor {
           if (NIS.debug.isLoggable(Level.FINE)) {
             NIS.debug.fine("Matches falsified inv " + inv.format());
           }
-          return (state = NIS.SuppressState.MATCH);
+          state = NIS.SuppressState.MATCH;
+          return state;
         }
       }
 
@@ -370,13 +379,15 @@ public class NISuppressor {
         if (!valid) {
           current_state_str = "not " + current_state_str;
         }
-        return (state = (valid ? NIS.SuppressState.VALID : NIS.SuppressState.INVALID));
+        state = (valid ? NIS.SuppressState.VALID : NIS.SuppressState.INVALID);
+        return state;
       }
 
       // Check to see if either variable is missing
       if (ppt.is_prev_missing(v1) || ppt.is_prev_missing(v2)) {
         current_state_str = "nonsensical";
-        return (state = NIS.SuppressState.NONSENSICAL);
+        state = NIS.SuppressState.NONSENSICAL;
+        return state;
       }
 
       // Check to see if this suppressor is true.  Note that we don't check
@@ -394,12 +405,14 @@ public class NISuppressor {
                   "suppressor matches inv " + slice_inv.format() + " " + !slice_inv.is_false());
             }
             current_state_str = "invariant " + slice_inv.format();
-            return (state = NIS.SuppressState.VALID);
+            state = NIS.SuppressState.VALID;
+            return state;
           }
         }
       }
       NIS.debug.fine("suppressor not found");
-      return (state = NIS.SuppressState.INVALID);
+      state = NIS.SuppressState.INVALID;
+      return state;
     }
   }
 

--- a/java/daikon/test/inv/InvariantAddAndCheckTester.java
+++ b/java/daikon/test/inv/InvariantAddAndCheckTester.java
@@ -329,7 +329,7 @@ public class InvariantAddAndCheckTester {
      *
      * @return a string containing error messages for any failed cases
      */
-    public static @Nullable String runTest(LineNumberReader commands) {
+    static @Nullable String runTest(LineNumberReader commands) {
       boolean endOfFile = initFields(commands, false);
       if (endOfFile) {
         return null;
@@ -359,7 +359,7 @@ public class InvariantAddAndCheckTester {
      *     test case
      */
     @SuppressWarnings("UnusedMethod")
-    public static @Nullable String generateTest(LineNumberReader commands) {
+    static @Nullable String generateTest(LineNumberReader commands) {
       boolean endOfFile = initFields(commands, true);
       if (endOfFile) {
         return null;

--- a/java/daikon/tools/jtb/AnnotateVisitor.java
+++ b/java/daikon/tools/jtb/AnnotateVisitor.java
@@ -352,7 +352,7 @@ public class AnnotateVisitor extends DepthFirstVisitor {
       Node n;
       boolean behaviorInserted;
 
-      public InsertBehaviorVisitor(Node n) {
+      InsertBehaviorVisitor(Node n) {
         super();
         this.n = n;
         behaviorInserted = false;
@@ -1005,10 +1005,10 @@ public class AnnotateVisitor extends DepthFirstVisitor {
   }
 
   private static class InvariantsAndModifiedVars {
-    public List<Invariant> invariants;
-    public String modifiedVars;
+    List<Invariant> invariants;
+    String modifiedVars;
 
-    public InvariantsAndModifiedVars(List<Invariant> invariants, String modifiedVars) {
+    InvariantsAndModifiedVars(List<Invariant> invariants, String modifiedVars) {
       this.invariants = invariants;
       this.modifiedVars = modifiedVars;
     }

--- a/java/daikon/tools/jtb/AnnotateVisitor.java
+++ b/java/daikon/tools/jtb/AnnotateVisitor.java
@@ -1006,7 +1006,8 @@ public class AnnotateVisitor extends DepthFirstVisitor {
 
   private static class InvariantsAndModifiedVars {
     final List<Invariant> invariants;
-    final String modifiedVars;
+    // `modifiedVars` cannot be final.
+    String modifiedVars;
 
     InvariantsAndModifiedVars(List<Invariant> invariants, String modifiedVars) {
       this.invariants = invariants;

--- a/java/daikon/tools/jtb/AnnotateVisitor.java
+++ b/java/daikon/tools/jtb/AnnotateVisitor.java
@@ -1005,8 +1005,8 @@ public class AnnotateVisitor extends DepthFirstVisitor {
   }
 
   private static class InvariantsAndModifiedVars {
-    List<Invariant> invariants;
-    String modifiedVars;
+    final List<Invariant> invariants;
+    final String modifiedVars;
 
     InvariantsAndModifiedVars(List<Invariant> invariants, String modifiedVars) {
       this.invariants = invariants;

--- a/java/daikon/tools/jtb/Ast.java
+++ b/java/daikon/tools/jtb/Ast.java
@@ -490,7 +490,7 @@ public class Ast {
       private final NodeToken comment;
       private final boolean first;
 
-      public AddCommentVisitor(NodeToken comment, boolean first) {
+      AddCommentVisitor(NodeToken comment, boolean first) {
         this.comment = comment;
         this.first = first;
       }
@@ -551,7 +551,7 @@ public class Ast {
       private final NodeToken comment;
       private final boolean first;
 
-      public AddCommentVisitor(NodeToken comment, boolean first) {
+      AddCommentVisitor(NodeToken comment, boolean first) {
         this.comment = comment;
         this.first = first;
       }
@@ -614,7 +614,7 @@ public class Ast {
     // After the traversal, the "lastNodeToken" slot contains the
     // last NodeToken visited.
     class LastNodeTokenVisitor extends DepthFirstVisitor {
-      public NodeToken lastNodeToken = null;
+      NodeToken lastNodeToken = null;
 
       @Override
       public void visit(NodeToken node) {
@@ -626,10 +626,10 @@ public class Ast {
     // descendant of the token from whcih traversal starts.)
     class NextNodeTokenVisitor extends DepthFirstVisitor {
       private boolean seenPredecessor = false;
-      public NodeToken nextNodeToken;
+      NodeToken nextNodeToken;
       private final NodeToken predecessor;
 
-      public NextNodeTokenVisitor(NodeToken predecessor) {
+      NextNodeTokenVisitor(NodeToken predecessor) {
         this.predecessor = predecessor;
       }
 
@@ -1001,10 +1001,10 @@ public class Ast {
   // returns true if, for some node in the tree, node.tokenImage.equals(s)
   public static boolean contains(Node n, String s) {
     class ContainsVisitor extends DepthFirstVisitor {
-      public boolean found = false;
+      boolean found = false;
       private final String s;
 
-      public ContainsVisitor(String s) {
+      ContainsVisitor(String s) {
         this.s = s;
       }
 
@@ -1043,7 +1043,7 @@ public class Ast {
   // parameters.
   public static List<FormalParameter> getParameters(MethodDeclaration m) {
     class GetParametersVisitor extends DepthFirstVisitor {
-      public List<FormalParameter> parameters = new ArrayList<>();
+      List<FormalParameter> parameters = new ArrayList<>();
 
       @Override
       public void visit(FormalParameter p) {
@@ -1061,7 +1061,7 @@ public class Ast {
   // inner classes.
   public static List<FormalParameter> getParametersNoImplicit(ConstructorDeclaration cd) {
     class GetParametersVisitor extends DepthFirstVisitor {
-      public List<FormalParameter> parameters = new ArrayList<>();
+      List<FormalParameter> parameters = new ArrayList<>();
 
       @Override
       public void visit(FormalParameter p) {
@@ -1079,7 +1079,7 @@ public class Ast {
   // parameters.
   public static List<FormalParameter> getParameters(ConstructorDeclaration cd) {
     class GetParametersVisitor extends DepthFirstVisitor {
-      public List<FormalParameter> parameters = new ArrayList<>();
+      List<FormalParameter> parameters = new ArrayList<>();
 
       @Override
       public void visit(FormalParameter p) {
@@ -1147,7 +1147,7 @@ public class Ast {
   public static Set<String> getVariableNames(Node expr) {
 
     class GetSymbolNamesVisitor extends DepthFirstVisitor {
-      public Set<String> symbolNames = new HashSet<>();
+      Set<String> symbolNames = new HashSet<>();
 
       @Override
       public void visit(Name n) {

--- a/java/daikon/tools/runtimechecker/InstrumentHandler.java
+++ b/java/daikon/tools/runtimechecker/InstrumentHandler.java
@@ -189,10 +189,10 @@ public class InstrumentHandler extends CommandHandler {
 
   @UsesObjectEquals
   private static class Arguments {
-    public String invFile;
-    public List<String> javaFileNames;
+    String invFile;
+    List<String> javaFileNames;
 
-    public Arguments(String invFile, List<String> javaFileNames) {
+    Arguments(String invFile, List<String> javaFileNames) {
       this.invFile = invFile;
       this.javaFileNames = javaFileNames;
     }

--- a/java/daikon/tools/runtimechecker/InstrumentVisitor.java
+++ b/java/daikon/tools/runtimechecker/InstrumentVisitor.java
@@ -503,7 +503,7 @@ public class InstrumentVisitor extends DepthFirstVisitor {
             Ast.create(
                 "ClassOrInterfaceBodyDeclaration",
                 new Class[] {Boolean.TYPE},
-                new Object[] {Boolean.FALSE}, // isInterface == false
+                new Object[] {false}, // isInterface == false
                 modifiers_declaration_stringbuffer.toString());
     Ast.addDeclaration(c, d);
     NodeSequence ns = (NodeSequence) d.f0.choice;
@@ -629,7 +629,7 @@ public class InstrumentVisitor extends DepthFirstVisitor {
         Ast.create(
             "ClassOrInterfaceBodyDeclaration",
             new Class[] {Boolean.TYPE},
-            new Object[] {Boolean.FALSE}, // isInterface == false
+            new Object[] {false}, // isInterface == false
             "public static boolean isDaikonInstrumented() { return true; }");
   }
 
@@ -642,7 +642,7 @@ public class InstrumentVisitor extends DepthFirstVisitor {
         Ast.create(
             "ClassOrInterfaceBodyDeclaration",
             new Class[] {Boolean.TYPE},
-            new Object[] {Boolean.FALSE}, // isInterface == false
+            new Object[] {false}, // isInterface == false
             code.toString());
   }
 
@@ -654,7 +654,7 @@ public class InstrumentVisitor extends DepthFirstVisitor {
         Ast.create(
             "ClassOrInterfaceBodyDeclaration",
             new Class[] {Boolean.TYPE},
-            new Object[] {Boolean.FALSE}, // isInterface == false
+            new Object[] {false}, // isInterface == false
             code.toString());
   }
 
@@ -689,7 +689,7 @@ public class InstrumentVisitor extends DepthFirstVisitor {
         Ast.create(
             "ClassOrInterfaceBodyDeclaration",
             new Class[] {Boolean.TYPE},
-            new Object[] {Boolean.FALSE}, // isInterface == false
+            new Object[] {false}, // isInterface == false
             code.toString());
   }
 
@@ -711,7 +711,7 @@ public class InstrumentVisitor extends DepthFirstVisitor {
         Ast.create(
             "ClassOrInterfaceBodyDeclaration",
             new Class[] {Boolean.TYPE},
-            new Object[] {Boolean.FALSE}, // isInterface == false
+            new Object[] {false}, // isInterface == false
             code.toString());
   }
 
@@ -732,7 +732,7 @@ public class InstrumentVisitor extends DepthFirstVisitor {
         Ast.create(
             "ClassOrInterfaceBodyDeclaration",
             new Class[] {Boolean.TYPE},
-            new Object[] {Boolean.FALSE}, // isInterface == false
+            new Object[] {false}, // isInterface == false
             code.toString());
   }
 
@@ -1113,13 +1113,13 @@ public class InstrumentVisitor extends DepthFirstVisitor {
 
   /** A pair consisting of an Invariant and its corresponding Property. */
   private static class InvProp {
-    public InvProp(Invariant inv, Property p) {
+    InvProp(Invariant inv, Property p) {
       this.invariant = inv;
       this.property = p;
     }
 
-    public Invariant invariant;
-    public Property property;
+    Invariant invariant;
+    Property property;
   }
 
   /**

--- a/java/lib/README
+++ b/java/lib/README
@@ -54,9 +54,10 @@ the command-line installation instructions up to date.)
 Instructions from https://errorprone.info/docs/installation#command-line :
 (cd error-prone && \
 export EP_VERSION=2.42.0 && \
-export DATAFLOW_EP_VERSION=3.51.0 && \
+export DATAFLOW_EP_VERSION=3.49.3 && \
 wget -N https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/${EP_VERSION?}/error_prone_core-${EP_VERSION?}-with-dependencies.jar && \
-wget -N https://repo1.maven.org/maven2/org/checkerframework/dataflow-errorprone/${DATAFLOW_EP_VERSION}/dataflow-errorprone-${DATAFLOW_EP_VERSION}.jar)
+wget -N https://repo1.maven.org/maven2/io/github/eisop/dataflow-errorprone/${DATAFLOW_EP_VERSION}-eisop1/dataflow-errorprone-${DATAFLOW_EP_VERSION}-eisop1.jar)
+# Older: wget -N https://repo1.maven.org/maven2/org/checkerframework/dataflow-errorprone/${DATAFLOW_EP_VERSION}/dataflow-errorprone-${DATAFLOW_EP_VERSION}.jar
 Also, update the version number in java/Makefile .
 
 hashmap-util-0.0.1.jar : https://central.sonatype.com/search?q=hashmap-util

--- a/java/lib/README
+++ b/java/lib/README
@@ -53,9 +53,10 @@ and even then failed with an error. (Error Prone isn't good about keeping
 the command-line installation instructions up to date.)
 Instructions from https://errorprone.info/docs/installation#command-line :
 (cd error-prone && \
-export EP_VERSION=2.15.0 && \
+export EP_VERSION=2.42.0 && \
+export DATAFLOW_EP_VERSION=3.51.0 && \
 wget -N https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/${EP_VERSION?}/error_prone_core-${EP_VERSION?}-with-dependencies.jar && \
-wget -N https://repo1.maven.org/maven2/org/checkerframework/dataflow-errorprone/3.15.0/dataflow-errorprone-3.15.0.jar)
+wget -N https://repo1.maven.org/maven2/org/checkerframework/dataflow-errorprone/${DATAFLOW_EP_VERSION}/dataflow-errorprone-${DATAFLOW_EP_VERSION}.jar)
 Also, update the version number in java/Makefile .
 
 hashmap-util-0.0.1.jar : https://central.sonatype.com/search?q=hashmap-util


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Java static-analysis and dataflow tooling to newer versions for Java 17+ and expanded compiler/annotation-processor access flags to improve builds on newer JDKs.
* **Refactor**
  * Tightened internal visibility and immutability of numerous helper members and simplified some return/assignment patterns; no behavioral changes.
* **Documentation**
  * Updated build/download notes and converted several comments to Javadoc; added a temporary PR helper file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->