### PR TITLE
Return as soon as the instrumentation decision is known

### DIFF
--- a/java/daikon/dcomp/DCInstrument.java
+++ b/java/daikon/dcomp/DCInstrument.java
@@ -2468,6 +2468,19 @@ public class DCInstrument extends InstructionListUtils {
       @ClassGetName String classname,
       @Identifier String methodName,
       Type[] paramTypes) {
+
+    if (invoke instanceof INVOKESPECIAL) {
+      // A call to the superclass constructor (super(...)) or to another constructor of this
+      // class (this(...)) both leave the receiver initialized: the delegated-to constructor runs
+      // the superclass constructor itself. Until one of them has been seen, `this` is
+      // uninitialized and tag fields must not be touched; see tag_fields_ok.
+      if (methodName.equals("<init>")
+          && (classname.equals(classGen.getSuperclassName())
+              || classname.equals(classGen.getClassName()))) {
+        this.constructor_is_initialized = true;
+      }
+    }
+
     boolean targetInstrumented;
 
     if (invoke instanceof INVOKEDYNAMIC) {
@@ -2476,9 +2489,9 @@ public class DCInstrument extends InstructionListUtils {
       if (debugHandleInvoke) {
         System.out.printf("invokedynamic NOT the classname: %s%n", classname);
       }
-      targetInstrumented = false;
+      return false;
     } else if (is_object_method(methodName, invoke.getArgumentTypes(pool))) {
-      targetInstrumented = false;
+      return false;
     } else {
       // At this point, we will never see classname = java.lang.Object.
       targetInstrumented =
@@ -2581,8 +2594,7 @@ public class DCInstrument extends InstructionListUtils {
               if (debugHandleInvoke) {
                 System.out.printf("Unable to locate class: %s%n%n", targetClassname);
               }
-              targetInstrumented = false;
-              break;
+              return false;
             }
             if (debugHandleInvoke) {
               System.out.println("target class: " + targetClassname);
@@ -2612,8 +2624,7 @@ public class DCInstrument extends InstructionListUtils {
                 found = getDefiningInterface(targetClass, methodName, paramTypes);
               } catch (Throwable e) {
                 // We cannot locate or read the .class file, better assume it is not instrumented.
-                targetInstrumented = false;
-                break;
+                return false;
               }
               if (found != null) {
                 // We have a match.
@@ -2635,25 +2646,12 @@ public class DCInstrument extends InstructionListUtils {
               if (debugHandleInvoke) {
                 System.out.printf("Unable to locate method: %s%n%n", methodName);
               }
-              targetInstrumented = false;
-              break;
+              return false;
             }
             // Recurse looking in the superclass.
             targetClassname = targetClass.getSuperclassName();
           }
         }
-      }
-    }
-
-    if (invoke instanceof INVOKESPECIAL) {
-      // A call to the superclass constructor (super(...)) or to another constructor of this
-      // class (this(...)) both leave the receiver initialized: the delegated-to constructor runs
-      // the superclass constructor itself. Until one of them has been seen, `this` is
-      // uninitialized and tag fields must not be touched; see tag_fields_ok.
-      if (methodName.equals("<init>")
-          && (classname.equals(classGen.getSuperclassName())
-              || classname.equals(classGen.getClassName()))) {
-        this.constructor_is_initialized = true;
       }
     }
 

--- a/java/daikon/dcomp/DCInstrument24.java
+++ b/java/daikon/dcomp/DCInstrument24.java
@@ -3129,8 +3129,20 @@ public class DCInstrument24 {
     boolean targetInstrumented;
     Opcode op = invoke.opcode();
 
+    if (op.equals(INVOKESPECIAL)) {
+      // A call to the superclass constructor (super(...)) or to another constructor of this
+      // class (this(...)) both leave the receiver initialized: the delegated-to constructor runs
+      // the superclass constructor itself. Until one of them has been seen, `this` is
+      // uninitialized and tag fields must not be touched; see tag_fields_ok.
+      if (methodName.equals("<init>")
+          && (classname.equals(classGen.getSuperclassName())
+              || classname.equals(classGen.getClassName()))) {
+        this.constructor_is_initialized = true;
+      }
+    }
+
     if (is_object_method(methodName, paramTypes)) {
-      targetInstrumented = false;
+      return false;
     } else {
       // At this point, we will never see classname = java.lang.Object.
       targetInstrumented =
@@ -3231,8 +3243,7 @@ public class DCInstrument24 {
               if (debugHandleInvoke) {
                 System.out.printf("Unable to locate class: %s%n%n", targetClassname);
               }
-              targetInstrumented = false;
-              break;
+              return false;
             }
             if (debugHandleInvoke) {
               System.out.println("target class: " + targetClassname);
@@ -3263,8 +3274,7 @@ public class DCInstrument24 {
                 found = getDefiningInterface(targetClass, methodName, paramTypes);
               } catch (Throwable e) {
                 // We cannot locate or read the .class file, better assume it is not instrumented.
-                targetInstrumented = false;
-                break;
+                return false;
               }
               if (found != null) {
                 // We have a match.
@@ -3285,26 +3295,13 @@ public class DCInstrument24 {
               if (debugHandleInvoke) {
                 System.out.printf("Unable to locate method: %s%n%n", methodName);
               }
-              targetInstrumented = false;
-              break;
+              return false;
             }
 
             // Recurse looking in the superclass.
             targetClassname = getSuperclassName(targetClassname);
           }
         }
-      }
-    }
-
-    if (op.equals(INVOKESPECIAL)) {
-      // A call to the superclass constructor (super(...)) or to another constructor of this
-      // class (this(...)) both leave the receiver initialized: the delegated-to constructor runs
-      // the superclass constructor itself. Until one of them has been seen, `this` is
-      // uninitialized and tag fields must not be touched; see tag_fields_ok.
-      if (methodName.equals("<init>")
-          && (classname.equals(classGen.getSuperclassName())
-              || classname.equals(classGen.getClassName()))) {
-        this.constructor_is_initialized = true;
       }
     }
 


### PR DESCRIPTION
Suggested by Michael Ernst in review of PR #685. Independent of #828 and #830.

`isTargetInstrumented` (BCEL) and its counterpart in `DCInstrument24` decide whether an invoke's target is instrumented. Several paths set `targetInstrumented = false` and broke out of the search only to fall through to the `return`. They now return directly.

### Why the two halves of this change belong together

The early returns are only safe because the `INVOKESPECIAL` handling moved to the **top** of the method. That block records that a `super(...)` or `this(...)` call has left the receiver initialized:

```java
if (methodName.equals("<init>")
    && (classname.equals(classGen.getSuperclassName())
        || classname.equals(classGen.getClassName()))) {
  this.constructor_is_initialized = true;
}
```

Left at the end, every new early-return path would silently skip it. That is not hypothetical: the same flag going unset is what produced a comparability regression in `Hanoi` during the Java 24 port, where a delegating constructor's field write emitted `discard_tag` instead of the field's `set_tag` accessor, moving the field out of the parameter's comparability set.

Moving it is safe because nothing between the old and new positions reads the flag. Its only reader is `tag_fields_ok`, reached from `load_store_field` -- a different method, applied to field-access instructions later in the walk. So a field read before the `super()` call still sees the flag unset, and one after still sees it set.

### Note on test coverage

The `DCInstrument24` half is covered: removing the flag assignment makes `delegatingConstructorInitializesReceiver` fail.

The `DCInstrument` half is **not**. `AllTestsSuite` contains no `DCInstrument` tests, so removing the same assignment there leaves the whole suite green. That half rests on compilation and on symmetry with the verified sibling. Flagging it because this change is specifically about preserving a side effect, and because the original `Hanoi` regression was caught only by the system tests.

### Testing

`make compile`, `make JAVA24=1 junit` (105 + 13), `make check-format`, `javadoc -Xdoclint:all`, and all six `typecheck-part1` checkers against the bundled Checker Framework are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1De2wQi77Zz4pnapvnFJz